### PR TITLE
ci: add workflow_dispatch trigger to all workflows

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   AWS_REGION: "us-east-1"


### PR DESCRIPTION
## Summary
Adds `workflow_dispatch:` trigger to workflows that were missing it.

**Files updated:**
- `.github/workflows/deploy-backend.yml`

**Why:** Manual/on-demand workflow triggering was not possible without this trigger.

---
*Created by Forge (JarvisXomware)*