### PR TITLE
fix: add AWS_DEFAULT_REGION to test conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 # Set required env vars before any imports that touch constants
 os.environ.setdefault("AWS_ACCOUNT_ID", "123456789012")
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
 os.environ.setdefault("DYNAMODB_KMS_ALIAS", "alias/test-key")
 os.environ.setdefault("LOG_LEVEL", "DEBUG")
 os.environ.setdefault("FROM_EMAIL", "noreply@xomper.xomware.com")


### PR DESCRIPTION
## Problem

3 DynamoDB safety guard tests fail in CI with `NoRegionError: You must specify a region` because `dynamo_helpers.py` creates boto3 clients at module import time and CI doesn't have `AWS_DEFAULT_REGION` set.

## Fix

Added `os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")` to `tests/conftest.py`. conftest runs before test imports, so the region is available when `dynamo_helpers.py` initializes its boto3 clients.

All 41 tests pass locally.