### PR TITLE
feat(ai-review F2): backend — preseason trigger lambda + prompts

### DIFF
--- a/lambdas/api_admin_ai_review_postdraft_trigger/prompts.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/prompts.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from lambdas.common.league_lore import LEAGUE_LORE, ManagerProfile
+from lambdas.common.lore_prompt import (
+    LORE_TEXT as _LORE_TEXT,
+    build_lore_block,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -50,45 +53,12 @@ Output format:
 
 
 # ---------------------------------------------------------------------------
-# System prompt — block 2 (lore, rendered at module load)
+# System prompt — block 2 (lore, factored to lambdas/common/lore_prompt.py)
 # ---------------------------------------------------------------------------
 
-
-def _render_profile(user_id: str, profile: ManagerProfile) -> str:
-    """Render a single ManagerProfile into the lore-section markdown
-    fragment the prompt expects."""
-    nicknames = ", ".join(profile.nicknames) if profile.nicknames else "(none)"
-    teams = ", ".join(profile.favorite_teams) if profile.favorite_teams else "(none)"
-    school = profile.school or "(unknown)"
-    stories = (
-        " | ".join(profile.notable_stories)
-        if profile.notable_stories
-        else "(none)"
-    )
-    life = " | ".join(profile.life_events) if profile.life_events else "(none)"
-    return (
-        f"### {profile.display_name}  (sleeper user_id: {user_id})\n"
-        f"- Nicknames: {nicknames}\n"
-        f"- Favorite teams: {teams}\n"
-        f"- School: {school}\n"
-        f"- Notable stories: {stories}\n"
-        f"- Life events: {life}\n"
-    )
-
-
-def _render_league_lore() -> str:
-    """Render the full LEAGUE_LORE map into the static lore block."""
-    rendered = "\n".join(
-        _render_profile(uid, profile) for uid, profile in LEAGUE_LORE.items()
-    )
-    return (
-        "LEAGUE LORE — the 12 managers and what to know about them. "
-        "Use this as the source of truth for any joke that references a person.\n\n"
-        f"{rendered}"
-    )
-
-
-SYSTEM_PROMPT_LORE = _render_league_lore()
+# Re-exported so callers + tests that have been importing the lore
+# constant from this module continue to work after the F2 refactor.
+SYSTEM_PROMPT_LORE = _LORE_TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -108,11 +78,7 @@ def build_system_blocks() -> list[dict[str, Any]]:
             "text": SYSTEM_PROMPT_TONE,
             "cache_control": {"type": "ephemeral"},
         },
-        {
-            "type": "text",
-            "text": SYSTEM_PROMPT_LORE,
-            "cache_control": {"type": "ephemeral"},
-        },
+        build_lore_block(),
     ]
 
 

--- a/lambdas/api_admin_ai_review_preseason_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/handler.py
@@ -1,0 +1,131 @@
+"""
+POST /admin/ai-review-preseason-trigger
+=======================================
+Admin-only endpoint that fires the F2 preseason AI Review pipeline.
+
+Mirrors the F1 post-draft trigger (see
+`api_admin_ai_review_postdraft_trigger.handler`). Same admin gate,
+same body shape, same response shape. The only differences are the
+pre-flight check (NFL state must be in `pre`/`off` season — i.e. the
+regular season hasn't started yet) and the period string
+(`"2026-PRESEASON"` vs F1's `"2026"`).
+
+Body:
+{
+    "sleeper_user_id": "abc123",     // required — admin gate identity
+    "email": "user@example.com",     // optional fallback identity
+    "dry_run": true,                 // optional, default true
+    "force": false                   // optional, default false
+}
+
+Behavior:
+- 200 + body on success (delivery counts + token usage + report row).
+- 400 on bad input.
+- 403 when the caller is not an admin.
+- 409 when a report already exists and `force=false`.
+- 412 when the regular season has already started (preseason window
+  has closed).
+- 502 when Anthropic / Sleeper external calls fail terminally.
+- 500 on everything else.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.admin_gate import NotAdmin, require_admin
+from lambdas.common.errors import (
+    PreseasonWindowPassedError,
+    ReportAlreadyExistsError,
+    XomperError,
+    handle_errors,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import parse_body, success_response
+
+from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+log = get_logger(__file__)
+HANDLER = "api_admin_ai_review_preseason_trigger"
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    log.info("Admin AI Review preseason trigger request")
+
+    body = parse_body(event)
+
+    try:
+        admin_user = require_admin(event, body)
+    except NotAdmin:
+        return success_response(
+            {"Success": False, "Message": "Not authorized"},
+            status_code=403,
+        )
+
+    dry_run = _coerce_bool(body.get("dry_run"), default=True)
+    force = _coerce_bool(body.get("force"), default=False)
+    created_by = admin_user.get("sleeper_user_id") or admin_user.get("id")
+
+    try:
+        result = run(
+            dry_run=dry_run,
+            force=force,
+            created_by_user_id=created_by,
+        )
+    except ReportAlreadyExistsError as err:
+        err.log_error()
+        return success_response(
+            {
+                "Success": False,
+                "error": "already_generated",
+                "Message": err.message,
+                "existing": err.details.get("existing"),
+            },
+            status_code=409,
+        )
+    except PreseasonWindowPassedError as err:
+        err.log_error()
+        return success_response(
+            {
+                "Success": False,
+                "error": "preseason_window_passed",
+                "Message": err.message,
+                "nfl_season": err.details.get("nfl_season"),
+                "season_type": err.details.get("season_type"),
+            },
+            status_code=412,
+        )
+    except XomperError as err:
+        # ClaudeAPIError / SleeperAPIError / DynamoDBError /
+        # ValidationError / NotFoundError all surface through here.
+        err.log_error()
+        return err.to_response()
+
+    return success_response(
+        {
+            "Success": True,
+            "status": result["status"],
+            "report": result.get("report"),
+            "dry_run": result["dry_run"],
+            "delivery_count": result["delivery_count"],
+            "model": result["model"],
+            "token_usage": result["token_usage"],
+        }
+    )
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    """Map the API GW body's `bool | "true" | "false" | 1 | 0` shapes
+    to a Python bool. Anything else falls back to `default`."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        if value.strip().lower() in {"true", "1", "yes"}:
+            return True
+        if value.strip().lower() in {"false", "0", "no"}:
+            return False
+    return default

--- a/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
@@ -1,0 +1,481 @@
+"""
+Preseason AI Review orchestrator
+================================
+Pure orchestration logic for F2. Mirrors the F1 post-draft
+orchestrator shape — handler stays tiny, this module is testable
+without faking API Gateway events.
+
+Flow (see `docs/features/ai-review/f2-preseason/PLAN.md`):
+
+1. Resolve the active whitelisted league.
+2. Idempotency: bail with `ReportAlreadyExistsError` if a row exists
+   for `(league_id, "preseason", "2026-PRESEASON")` and `force=False`.
+3. Pre-flight: confirm NFL state's `season_type` is `pre` or `off`.
+   If the regular season has already started, raise
+   `PreseasonWindowPassedError`.
+4. Pull data — this year's rosters + users, last year's
+   rosters + users (walked via `previous_league_id`).
+5. Build the system + user prompts, call `claude_helper.generate`.
+6. Persist via `ai_reports_store.write_report` with token-usage
+   metadata.
+7. Deliver via SES + SNS (single admin for dry-run, all 12 for
+   broadcast). Stamp `metadata.broadcast_at` on the non-dry-run path.
+
+Returns a dict suitable for JSON-encoding in the API response.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from lambdas.common import ai_reports_store, claude_helper
+from lambdas.common.constants import (
+    ADMIN_DOMINICK_USER_ID,
+    AI_REVIEW_DEFAULT_MODEL,
+    AI_REVIEW_PRESEASON_MAX_TOKENS,
+    AI_REVIEW_PRESEASON_OK_SEASON_TYPES,
+    AI_REVIEW_PRESEASON_PERIOD,
+    AI_REVIEW_PRESEASON_PROMPT_VERSION,
+)
+from lambdas.common.email_templates.ai_review import build_email_payload
+from lambdas.common.errors import (
+    NotFoundError,
+    PreseasonWindowPassedError,
+    ReportAlreadyExistsError,
+)
+from lambdas.common.logger import get_logger
+from lambdas.common.ses_helper import send_emails_concurrently
+from lambdas.common.sleeper_helper import (
+    get_nfl_state,
+    get_previous_league_id,
+    get_sleeper_league,
+    get_sleeper_league_rosters,
+    get_sleeper_league_users,
+)
+from lambdas.common.sns_helper import send_push_to_users
+from lambdas.common.supabase_helper import (
+    get_active_whitelisted_league,
+    get_active_whitelisted_users,
+)
+
+from lambdas.api_admin_ai_review_preseason_trigger.prompts import (
+    build_system_blocks,
+    build_user_prompt,
+)
+
+log = get_logger(__file__)
+
+REPORT_TYPE = "preseason"
+PUSH_TITLE_BROADCAST = "Your preseason AI review is in"
+PUSH_BODY_BROADCAST = "Tap to see last year's grade + this year's outlook."
+PUSH_TITLE_DRY_RUN = "[DRY RUN] Preseason AI review ready"
+PUSH_BODY_DRY_RUN = "Tap to preview before broadcasting."
+DEEP_LINK = f"xomper://ai-review/preseason/{AI_REVIEW_PRESEASON_PERIOD}"
+PUSH_CATEGORY = "AI_REVIEW"
+
+
+def run(
+    *,
+    dry_run: bool = True,
+    force: bool = False,
+    created_by_user_id: str | None = None,
+) -> dict[str, Any]:
+    """Drive the preseason AI Review generation + delivery.
+
+    Args:
+        dry_run: When True (default), the generated report is still
+            written to Dynamo but only delivered to
+            `ADMIN_DOMINICK_USER_ID` for tone calibration. When False,
+            broadcasts to all 12 league managers.
+        force: When False (default), an existing report for this
+            league/type/period raises `ReportAlreadyExistsError`.
+            When True, overwrites the existing row.
+        created_by_user_id: Sleeper user_id of the admin who fired the
+            trigger. Stamped into `metadata` for auditability.
+
+    Returns:
+        Dict carrying `report_id`, `dry_run`, `delivery_count`,
+        `model`, `token_usage`, `status`, `report`. The handler
+        wraps this for the API response.
+
+    Raises:
+        PreseasonWindowPassedError: NFL state shows the regular
+            season has already started.
+        ReportAlreadyExistsError: Existing row + force=False.
+        NotFoundError: No active whitelisted league configured.
+        ClaudeAPIError: Anthropic call failed after retries.
+    """
+    league_row = get_active_whitelisted_league()
+    if not league_row:
+        raise NotFoundError(
+            message="No active whitelisted league configured",
+            handler="notif_ai_review_preseason",
+            function="run",
+            resource="whitelisted_leagues",
+        )
+    league_id = (
+        league_row.get("sleeper_league_id")
+        or league_row.get("league_id")
+        or ""
+    )
+    if not league_id:
+        raise NotFoundError(
+            message="Active league row is missing sleeper_league_id",
+            handler="notif_ai_review_preseason",
+            function="run",
+            resource="whitelisted_leagues",
+        )
+
+    period = AI_REVIEW_PRESEASON_PERIOD
+
+    # 1. Idempotency
+    existing = ai_reports_store.get_latest(league_id, REPORT_TYPE)
+    if existing and not force:
+        raise ReportAlreadyExistsError(
+            message="A preseason report already exists for this league",
+            handler="notif_ai_review_preseason",
+            existing={
+                "league_id": existing.get("league_id"),
+                "report_type": existing.get("report_type"),
+                "period": existing.get("period"),
+                "created_at": existing.get("created_at"),
+            },
+        )
+
+    # 2. Pre-flight: confirm the regular season has not yet started.
+    nfl_state = get_nfl_state() or {}
+    season_type = (nfl_state.get("season_type") or "").lower()
+    nfl_season = str(nfl_state.get("season") or "")
+    if season_type and season_type not in AI_REVIEW_PRESEASON_OK_SEASON_TYPES:
+        raise PreseasonWindowPassedError(
+            message=(
+                f"Regular season already underway "
+                f"(NFL season={nfl_season!r}, season_type={season_type!r})"
+            ),
+            nfl_season=nfl_season,
+            season_type=season_type,
+        )
+
+    # 3. Load data
+    league = get_sleeper_league(league_id)
+    sleeper_users = get_sleeper_league_users(league_id)
+    rosters = get_sleeper_league_rosters(league_id)
+
+    prior_league_id = get_previous_league_id(league_id)
+    prior_standings: list[dict[str, Any]] = []
+    if prior_league_id:
+        try:
+            prior_rosters = get_sleeper_league_rosters(prior_league_id)
+            prior_users = get_sleeper_league_users(prior_league_id)
+            prior_standings = _build_prior_standings(prior_rosters, prior_users)
+        except Exception as err:  # noqa: BLE001 — prior season is best-effort
+            log.warning(
+                f"prior-standings fetch failed for league {prior_league_id}: "
+                f"{err}; continuing without prior standings"
+            )
+
+    team_rosters = _build_current_rosters(
+        rosters=rosters,
+        sleeper_users=sleeper_users,
+        prior_standings=prior_standings,
+    )
+
+    league_name = league.get("name") or league_row.get("league_name") or "League"
+    season = str(league.get("season") or nfl_season or "2026")
+
+    # 4. Build prompts + generate
+    system_blocks = build_system_blocks()
+    user_prompt = build_user_prompt(
+        league_name=league_name,
+        season=season,
+        team_rosters=team_rosters,
+        prior_standings=prior_standings,
+    )
+
+    markdown, token_usage = claude_helper.generate(
+        prompt=user_prompt,
+        system=system_blocks,
+        model=AI_REVIEW_DEFAULT_MODEL,
+        max_tokens=AI_REVIEW_PRESEASON_MAX_TOKENS,
+        return_usage=True,
+    )
+
+    # 5. Persist
+    metadata: dict[str, Any] = {
+        "dry_run": dry_run,
+        "force": force,
+        "model": AI_REVIEW_DEFAULT_MODEL,
+        "prompt_version": AI_REVIEW_PRESEASON_PROMPT_VERSION,
+        "token_usage": token_usage,
+        "nfl_season": nfl_season,
+        "nfl_season_type": season_type,
+        "prior_league_id": prior_league_id,
+        "broadcast_at": None,
+    }
+    if created_by_user_id:
+        metadata["created_by_user_id"] = created_by_user_id
+
+    report_row = ai_reports_store.write_report(
+        league_id=league_id,
+        report_type=REPORT_TYPE,
+        period=period,
+        body_markdown=markdown,
+        metadata=metadata,
+    )
+
+    # 6. Deliver
+    delivery_count = _deliver(
+        dry_run=dry_run,
+        league_id=league_id,
+        league_name=league_name,
+        body_markdown=markdown,
+        period=period,
+    )
+
+    # 7. Stamp broadcast_at on the non-dry-run path
+    if not dry_run:
+        broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            ai_reports_store.update_metadata(
+                league_id=league_id,
+                report_type=REPORT_TYPE,
+                period=period,
+                partial={"broadcast_at": broadcast_at},
+            )
+            metadata["broadcast_at"] = broadcast_at
+            report_row["metadata"] = metadata
+        except Exception as err:  # noqa: BLE001 — non-blocking
+            log.warning(f"update_metadata broadcast_at failed: {err}")
+
+    status = "dry_run_sent" if dry_run else "broadcast"
+    return {
+        "status": status,
+        "report_id": report_row.get("sk"),
+        "report": report_row,
+        "dry_run": dry_run,
+        "delivery_count": delivery_count,
+        "model": AI_REVIEW_DEFAULT_MODEL,
+        "token_usage": token_usage,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_prior_standings(
+    rosters: list[dict[str, Any]],
+    users: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Convert Sleeper rosters + users into a sorted standings list.
+
+    Sleeper rosters carry `settings.wins`, `losses`, `ties`, `fpts`,
+    `fpts_decimal`, `fpts_against`, `fpts_against_decimal`. Sort by
+    wins desc, then points-for desc.
+    """
+    users_by_id = {u.get("user_id"): u for u in users}
+    rows: list[dict[str, Any]] = []
+    for roster in rosters:
+        settings = roster.get("settings") or {}
+        owner_id = roster.get("owner_id")
+        user = users_by_id.get(owner_id, {}) if owner_id else {}
+        team_name = (user.get("metadata") or {}).get("team_name")
+        display_name = user.get("display_name") or "Unknown"
+
+        wins = int(settings.get("wins") or 0)
+        losses = int(settings.get("losses") or 0)
+        ties = int(settings.get("ties") or 0)
+        pf_whole = settings.get("fpts") or 0
+        pf_dec = settings.get("fpts_decimal") or 0
+        pa_whole = settings.get("fpts_against") or 0
+        pa_dec = settings.get("fpts_against_decimal") or 0
+        points_for = float(pf_whole) + (float(pf_dec) / 100.0)
+        points_against = float(pa_whole) + (float(pa_dec) / 100.0)
+
+        rows.append(
+            {
+                "user_id": owner_id,
+                "manager_display_name": display_name,
+                "team_name": team_name,
+                "wins": wins,
+                "losses": losses,
+                "ties": ties,
+                "points_for": points_for,
+                "points_against": points_against,
+            }
+        )
+
+    rows.sort(key=lambda r: (-r["wins"], -r["points_for"]))
+    for idx, row in enumerate(rows, start=1):
+        row["rank"] = idx
+        if idx == 1:
+            row["playoff_note"] = "won the chip"
+        elif idx <= 4:
+            row["playoff_note"] = "made the playoffs"
+        elif idx == len(rows):
+            row["playoff_note"] = "finished last"
+        else:
+            row["playoff_note"] = ""
+    return rows
+
+
+def _build_current_rosters(
+    *,
+    rosters: list[dict[str, Any]],
+    sleeper_users: list[dict[str, Any]],
+    prior_standings: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Group player_ids by manager from this year's rosters.
+
+    Returns one dict per manager, sorted by `roster_id` asc (stable
+    proxy for draft-slot ordering on the backend, which doesn't have
+    access to the iOS `historyStore.upcomingDraft`). Each manager dict
+    carries:
+      - `roster_id` (int)
+      - `user_id` (str | None)
+      - `manager_display_name` (str)
+      - `team_name` (str | None)
+      - `player_ids` (list[str])  — keeper / starter pool from the
+        current Sleeper roster snapshot
+      - `prior_finish` (dict | None)  — `{rank, wins, losses, ties,
+        points_for}` lifted from the matched prior-standings row, or
+        None when there's no prior season
+      - `position_counts` (dict[str, int]) — best-effort breakdown
+        keyed off Sleeper's `roster_positions` slots (empty when
+        positional data isn't available)
+    """
+    users_by_id = {u.get("user_id"): u for u in sleeper_users}
+    prior_by_user = {
+        row.get("user_id"): row for row in prior_standings if row.get("user_id")
+    }
+
+    summaries: list[dict[str, Any]] = []
+    for roster in rosters:
+        owner_id = roster.get("owner_id")
+        user = users_by_id.get(owner_id, {}) if owner_id else {}
+        team_name = (user.get("metadata") or {}).get("team_name")
+        display_name = user.get("display_name") or "Unknown"
+
+        players = roster.get("players") or []
+        # Sleeper roster `players` is a list of player_id strings.
+        player_ids = [str(pid) for pid in players if pid]
+
+        starters_raw = roster.get("starters") or []
+        starters = [str(pid) for pid in starters_raw if pid and pid != "0"]
+
+        prior_row = prior_by_user.get(owner_id)
+        prior_finish: dict[str, Any] | None = None
+        if prior_row:
+            prior_finish = {
+                "rank": prior_row.get("rank"),
+                "wins": prior_row.get("wins"),
+                "losses": prior_row.get("losses"),
+                "ties": prior_row.get("ties"),
+                "points_for": prior_row.get("points_for"),
+            }
+
+        summaries.append(
+            {
+                "roster_id": roster.get("roster_id"),
+                "user_id": owner_id,
+                "manager_display_name": display_name,
+                "team_name": team_name,
+                "player_ids": player_ids,
+                "starters": starters,
+                "player_count": len(player_ids),
+                "prior_finish": prior_finish,
+            }
+        )
+
+    summaries.sort(key=lambda r: (r.get("roster_id") or 999))
+    return summaries
+
+
+def _deliver(
+    *,
+    dry_run: bool,
+    league_id: str,
+    league_name: str,
+    body_markdown: str,
+    period: str,
+) -> int:
+    """Build per-user email payloads + push notifications and fan
+    them out. Returns the number of recipients we attempted to
+    deliver to (not the number of successful sends — per-channel
+    success is logged via the existing notification_log path)."""
+    recipients = _resolve_recipients(dry_run=dry_run)
+    if not recipients:
+        log.warning(
+            f"No recipients resolved for AI Review delivery "
+            f"(dry_run={dry_run}, league={league_id})"
+        )
+        return 0
+
+    period_label = f"Preseason {period}"
+    email_tasks: list[tuple[str, str, str, str]] = []
+    push_user_ids: list[str] = []
+
+    for recipient in recipients:
+        sleeper_user_id = recipient.get("sleeper_user_id")
+        email = recipient.get("email")
+        first_name = (
+            recipient.get("display_name")
+            or recipient.get("sleeper_username")
+            or "there"
+        )
+        if email:
+            payload = build_email_payload(
+                user_email=email,
+                user_first_name=first_name,
+                report_type=REPORT_TYPE,
+                body_markdown=body_markdown,
+                period_label=period_label,
+                league_name=league_name,
+            )
+            subject = payload["subject"]
+            if dry_run:
+                subject = f"[DRY RUN] {subject}"
+            email_tasks.append(
+                (
+                    email,
+                    subject,
+                    payload["html_body"],
+                    payload["text_body"],
+                )
+            )
+        if sleeper_user_id:
+            push_user_ids.append(sleeper_user_id)
+
+    if email_tasks:
+        send_emails_concurrently(email_tasks)
+
+    if push_user_ids:
+        title = PUSH_TITLE_DRY_RUN if dry_run else PUSH_TITLE_BROADCAST
+        body = PUSH_BODY_DRY_RUN if dry_run else PUSH_BODY_BROADCAST
+        send_push_to_users(
+            push_user_ids,
+            title,
+            body,
+            PUSH_CATEGORY,
+            {"url": DEEP_LINK, "period": period},
+        )
+
+    return len(recipients)
+
+
+def _resolve_recipients(*, dry_run: bool) -> list[dict[str, Any]]:
+    """For dry_run, return the single admin-row (resolved from the
+    whitelisted_users table). For broadcast, return all active users."""
+    all_users = get_active_whitelisted_users()
+    if dry_run:
+        admin = next(
+            (
+                u
+                for u in all_users
+                if u.get("sleeper_user_id") == ADMIN_DOMINICK_USER_ID
+            ),
+            None,
+        )
+        return [admin] if admin else []
+    return all_users

--- a/lambdas/api_admin_ai_review_preseason_trigger/prompts.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/prompts.py
@@ -1,0 +1,247 @@
+"""
+Preseason AI Review prompts
+===========================
+Pure functions that build the system + user prompts for F2's
+preseason "year-in-review + outlook" analysis. Kept separate from
+`handler.py` so the prompt text is unit-testable in isolation and
+changes go through normal PR review.
+
+The system prompt is a 2-block payload (tone+safety re-anchored on
+preseason, lore via the shared `lore_prompt` helper) — each block is
+sent to Anthropic with `cache_control: ephemeral` so re-runs reuse
+the cached prefix and so the lore tokens amortize across F1 + F2 +
+F3 when calls land within the cache TTL.
+
+User prompt: this year's roster snapshot per team (`player_id`
+strings — no name resolution in v1) + last year's final standings
+per team. Ordered by `roster_id` asc on the backend (proxy for the
+draft-slot ordering the iOS client uses).
+
+Pinned `PROMPT_VERSION` is `f2-preseason-2026-05-21`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.constants import AI_REVIEW_PRESEASON_PROMPT_VERSION
+from lambdas.common.lore_prompt import (
+    LORE_TEXT as _LORE_TEXT,
+    build_lore_block,
+)
+
+
+# Mirror of F1's PROMPT_VERSION convention — also re-exported as a
+# module constant so tests + metadata writes can pin against drift.
+PROMPT_VERSION = AI_REVIEW_PRESEASON_PROMPT_VERSION
+
+
+# ---------------------------------------------------------------------------
+# System prompt — block 1 (tone + safety, re-anchored for preseason)
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT_TONE = """You are the resident sports-talk-radio host for the Xomper fantasy football league, a 12-person dynasty league of college friends. Your job is to write the preseason year-in-review + season outlook report, fired in late August / early September before Week 1 kickoff.
+
+Voice:
+- Funny, unserious, lightly mean. Roast each manager by name.
+- You're roasting your friends about their fantasy futures, leaning on last year's wins and losses and the lineup they're walking into Week 1 with. Personal but never cruel. Specific, not generic.
+- Lean on inside jokes from the lore section below.
+- Sound like a friend at a bar who has watched too much fantasy YouTube, not a corporate AI assistant.
+- No corporate hedge phrases. No "however, on the other hand…". No "as an AI language model". Never apologize.
+- Short punchy paragraphs. Use markdown headings (H2 per team).
+
+Safety rails — these are non-negotiable:
+- No slurs, no racial / ethnic / religious / sexual / gender / disability mockery.
+- No jokes about substance abuse, addiction, eating disorders, self-harm, suicide, or mental health crises.
+- No jokes about violence against people (real or implied).
+- No jokes about anyone NOT in the lore section. Do not invent league members.
+- No sexual content. Keep it PG-13 frat-house humor, not locker-room cruelty.
+- Do NOT invent NFL news, injuries, arrests, trades, or suspensions. If you don't have data on a player_id in the user prompt, lean on your training-data knowledge but treat them as a generic player at their position when in doubt — never fabricate news events.
+- Do not reference specific real-world tragedies, deaths, or news events.
+- If a roast feels like it crosses a line, soften it. Better to tame than to land wrong.
+
+Output format:
+- Open with a one-paragraph league-wide intro setting up the year — last year's chip winner, last year's basement team, who's hungry, who's coasting.
+- Then one H2 section per team, in the same order as the team rosters provided in the user prompt (sorted by roster_id ascending).
+- Each team section is ~2 short paragraphs: first paragraph is the year-in-review (one or two lines about last year's record + PF), second paragraph is the outlook for the coming year tying the current roster + a lore tidbit together.
+- Every paragraph must reference at least one concrete data point: a record from last year, a points-for total, a specific player_id from the current roster, or a known lore tidbit.
+- End with a one-paragraph closer projecting who you think wins it all this year and who's drafting in the basement again.
+- Output pure markdown. No HTML. No code fences around the markdown. Use **bold** for emphasis and `>` for the occasional one-liner pull-quote."""
+
+
+# ---------------------------------------------------------------------------
+# System prompt — block 2 (lore, sourced from lambdas/common/lore_prompt.py)
+# ---------------------------------------------------------------------------
+
+# Re-exported so callers + tests that want to assert against the lore
+# content can pull it from this module alongside `SYSTEM_PROMPT_TONE`.
+SYSTEM_PROMPT_LORE = _LORE_TEXT
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def build_system_blocks() -> list[dict[str, Any]]:
+    """Return the two-block system prompt payload Anthropic expects.
+
+    Each block is tagged with `cache_control: ephemeral` so that the
+    tone+safety scaffolding and the league lore are cached across
+    subsequent calls (dry-run + force re-runs land warm)."""
+    return [
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT_TONE,
+            "cache_control": {"type": "ephemeral"},
+        },
+        build_lore_block(),
+    ]
+
+
+def build_user_prompt(
+    *,
+    league_name: str,
+    season: str,
+    team_rosters: list[dict[str, Any]],
+    prior_standings: list[dict[str, Any]] | None,
+) -> str:
+    """Build the per-report user prompt.
+
+    Args:
+        league_name: Sleeper league name (e.g. "CLT DYNASTY").
+        season: The upcoming season as a string (e.g. "2026").
+        team_rosters: One dict per manager, sorted by roster_id asc.
+            Each dict carries:
+              - `roster_id` (int)
+              - `manager_display_name` (str)
+              - `team_name` (str | None)
+              - `user_id` (str | None)
+              - `player_ids`: list of player_id strings
+              - `starters`: list of player_id strings (best-effort)
+              - `prior_finish`: optional dict with `{rank, wins,
+                losses, ties, points_for}` from last year, or None
+        prior_standings: Optional list of `{rank, manager_display_name,
+            team_name, wins, losses, ties, points_for, points_against,
+            playoff_note}` dicts, sorted best -> worst. Pass `None` or
+            empty when the prior season isn't available.
+
+    Returns:
+        The user message to send as the `user` role in Anthropic's
+        Messages API.
+    """
+    lines: list[str] = []
+    lines.append(
+        f"This is the {season} preseason. Here is the data for the league "
+        f"\"{league_name}\"."
+    )
+    lines.append("")
+
+    # --- prior standings table -------------------------------------------------
+    prior_year = _prior_year_label(season)
+    lines.append(f"## Final {prior_year} Standings")
+    lines.append("")
+    if not prior_standings:
+        lines.append(
+            "_Prior season standings unavailable (inaugural season or "
+            "Sleeper history not linked). Skip the year-in-review angle "
+            "and roast on the outlook alone._"
+        )
+    else:
+        for row in prior_standings:
+            rank = row.get("rank")
+            mgr = row.get("manager_display_name") or "Unknown"
+            team_name = row.get("team_name") or mgr
+            wins = row.get("wins", 0)
+            losses = row.get("losses", 0)
+            ties = row.get("ties", 0)
+            pf = row.get("points_for", 0)
+            pa = row.get("points_against", 0)
+            note = row.get("playoff_note") or ""
+            record = f"{wins}-{losses}"
+            if ties:
+                record += f"-{ties}"
+            line = (
+                f"- #{rank} {mgr} ({team_name}) — {record}, "
+                f"PF {pf:.1f}, PA {pa:.1f}"
+            )
+            if note:
+                line += f" — {note}"
+            lines.append(line)
+    lines.append("")
+
+    # --- current roster snapshot ----------------------------------------------
+    lines.append(f"## {season} Rosters")
+    lines.append("")
+    if not team_rosters:
+        lines.append(
+            "_No current rosters available — treat this as a fresh league._"
+        )
+    else:
+        for team in team_rosters:
+            roster_id = team.get("roster_id")
+            name = team.get("manager_display_name") or "Unknown"
+            team_name = team.get("team_name")
+            prior = team.get("prior_finish") or {}
+            header_bits = [f"Roster #{roster_id}", name]
+            if team_name:
+                header_bits.append(f"({team_name})")
+            if prior:
+                wins = prior.get("wins", 0)
+                losses = prior.get("losses", 0)
+                ties = prior.get("ties", 0)
+                record = f"{wins}-{losses}"
+                if ties:
+                    record += f"-{ties}"
+                prior_pf = prior.get("points_for")
+                rank = prior.get("rank")
+                bits = []
+                if rank is not None:
+                    bits.append(f"#{rank}")
+                bits.append(record)
+                if prior_pf is not None:
+                    bits.append(f"{prior_pf:.1f} PF")
+                header_bits.append(f"[last year: {' / '.join(bits)}]")
+            lines.append(f"### {' '.join(header_bits)}")
+            player_ids = team.get("player_ids") or []
+            starters = team.get("starters") or []
+            if not player_ids:
+                lines.append("- (no players on roster)")
+            else:
+                lines.append(
+                    f"- Roster size: {len(player_ids)} "
+                    f"(starters: {len(starters)})"
+                )
+                if starters:
+                    lines.append(
+                        "- Starters: "
+                        + ", ".join(starters)
+                    )
+                bench = [pid for pid in player_ids if pid not in set(starters)]
+                if bench:
+                    lines.append("- Bench: " + ", ".join(bench))
+            lines.append("")
+
+    # --- task footer ----------------------------------------------------------
+    lines.append("## Your task")
+    lines.append("")
+    lines.append(
+        "Write a preseason recap that grades each manager on last year and "
+        "previews this year, with one H2 per team in roster_id ascending "
+        "order. Use the lore. Use the data. Don't invent injuries, trades, "
+        "or news that isn't in the data — player_ids are raw Sleeper IDs, "
+        "lean on training-data knowledge for player narratives but never "
+        "fabricate events. Keep each team section ~2 paragraphs."
+    )
+
+    return "\n".join(lines)
+
+
+def _prior_year_label(season: str) -> str:
+    """Best-effort guess at the prior-year label for the standings
+    header. Falls back to "the prior season" when the season string
+    isn't an integer year (e.g. "2026-PRESEASON")."""
+    try:
+        year = int(season)
+        return str(year - 1)
+    except (TypeError, ValueError):
+        return "the prior season"

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -30,8 +30,16 @@ DEVICE_TOKENS_TABLE = os.environ.get("DEVICE_TOKENS_TABLE", "xomper-device-token
 AI_REPORTS_TABLE = os.environ.get("AI_REPORTS_TABLE", "xomper-ai-reports")
 AI_REVIEW_PROMPT_VERSION = os.environ.get("AI_REVIEW_PROMPT_VERSION", "v1")
 AI_REVIEW_POSTDRAFT_PERIOD = "2026"
+AI_REVIEW_PRESEASON_PERIOD = "2026-PRESEASON"
+AI_REVIEW_PRESEASON_PROMPT_VERSION = os.environ.get(
+    "AI_REVIEW_PRESEASON_PROMPT_VERSION", "f2-preseason-2026-05-21"
+)
 AI_REVIEW_DEFAULT_MODEL = "claude-haiku-4-5"
 AI_REVIEW_MAX_TOKENS = 4000
+AI_REVIEW_PRESEASON_MAX_TOKENS = 6000
+# NFL state.season_type values that mean "regular season has not yet
+# started" — used as the preseason pre-flight gate.
+AI_REVIEW_PRESEASON_OK_SEASON_TYPES = ("pre", "off")
 
 # Admin user id for dry-run delivery (Dominick).
 ADMIN_DOMINICK_USER_ID = "594625531702460416"

--- a/lambdas/common/errors.py
+++ b/lambdas/common/errors.py
@@ -190,6 +190,34 @@ class DraftNotCompleteError(XomperError):
         )
 
 
+class PreseasonWindowPassedError(XomperError):
+    """Raised when the preseason AI Review trigger fires after the
+    regular-season window has already started (i.e. NFL state's
+    `season_type` is `regular` or `post`). Surfaces as HTTP 412
+    (Precondition Failed) to the admin client."""
+
+    def __init__(
+        self,
+        message: str = "Preseason window has already passed",
+        handler: str = "notif_ai_review_preseason",
+        function: str = "run",
+        nfl_season: Optional[str] = None,
+        season_type: Optional[str] = None,
+    ):
+        details: dict = {}
+        if nfl_season:
+            details["nfl_season"] = nfl_season
+        if season_type:
+            details["season_type"] = season_type
+        super().__init__(
+            message=message,
+            handler=handler,
+            function=function,
+            status=412,
+            details=details,
+        )
+
+
 class ReportAlreadyExistsError(XomperError):
     """Raised when an AI Review report already exists for a given
     `(league_id, report_type, period)` and the caller did not pass

--- a/lambdas/common/lore_prompt.py
+++ b/lambdas/common/lore_prompt.py
@@ -1,0 +1,76 @@
+"""
+Lore prompt helper
+==================
+Shared builder for the "LEAGUE LORE" system block used by every AI
+Review pipeline (F1 post-draft, F2 preseason, F3 weekly). Renders
+`league_lore.LEAGUE_LORE` into a single cached system block so the
+~3k-token lore payload is paid once per Anthropic cache TTL across
+re-runs and across pipelines.
+
+Extracted from `api_admin_ai_review_postdraft_trigger.prompts` during
+F2 so both lambdas import from the same source. Any future tweak to
+the rendered lore shape lives here.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.league_lore import LEAGUE_LORE, ManagerProfile
+
+
+def _render_profile(user_id: str, profile: ManagerProfile) -> str:
+    """Render a single ManagerProfile into the lore-section markdown
+    fragment the prompt expects."""
+    nicknames = ", ".join(profile.nicknames) if profile.nicknames else "(none)"
+    teams = ", ".join(profile.favorite_teams) if profile.favorite_teams else "(none)"
+    school = profile.school or "(unknown)"
+    stories = (
+        " | ".join(profile.notable_stories)
+        if profile.notable_stories
+        else "(none)"
+    )
+    life = " | ".join(profile.life_events) if profile.life_events else "(none)"
+    return (
+        f"### {profile.display_name}  (sleeper user_id: {user_id})\n"
+        f"- Nicknames: {nicknames}\n"
+        f"- Favorite teams: {teams}\n"
+        f"- School: {school}\n"
+        f"- Notable stories: {stories}\n"
+        f"- Life events: {life}\n"
+    )
+
+
+def render_league_lore_text() -> str:
+    """Render the full LEAGUE_LORE map into the static lore block text.
+
+    Returned as a plain string so callers can either embed it inside a
+    larger text payload or wrap it in a single cache-controlled
+    Anthropic block via `build_lore_block`.
+    """
+    rendered = "\n".join(
+        _render_profile(uid, profile) for uid, profile in LEAGUE_LORE.items()
+    )
+    return (
+        "LEAGUE LORE — the 12 managers and what to know about them. "
+        "Use this as the source of truth for any joke that references a person.\n\n"
+        f"{rendered}"
+    )
+
+
+def build_lore_block() -> dict[str, Any]:
+    """Return the lore as a single `{type, text, cache_control}` block.
+
+    Marks `cache_control={"type": "ephemeral"}` so re-runs within the
+    Anthropic cache TTL skip re-paying the lore-tokens cost.
+    """
+    return {
+        "type": "text",
+        "text": render_league_lore_text(),
+        "cache_control": {"type": "ephemeral"},
+    }
+
+
+# Module-level snapshot so callers that want the raw text don't pay
+# the rendering cost on every call (deterministic — LEAGUE_LORE is
+# immutable for the lifetime of the lambda container).
+LORE_TEXT = render_league_lore_text()

--- a/tests/test_api_admin_ai_review_preseason_trigger.py
+++ b/tests/test_api_admin_ai_review_preseason_trigger.py
@@ -1,0 +1,630 @@
+"""
+Tests for `api_admin_ai_review_preseason_trigger`.
+
+Covers the orchestrator's flow + the API handler's surface:
+  - 403 when caller is not an admin
+  - 409 when a report already exists (force=false)
+  - 412 when the regular season has already started
+  - 200 + delivery_count=1 for dry_run=true
+  - 200 + delivery_count=12 for dry_run=false, force=true
+  - Idempotency: a second force=false call after a write still 409s
+  - Prior-standings failure is non-blocking
+
+External integrations (Sleeper, Anthropic, SES, SNS, Supabase,
+DynamoDB ai_reports_store) are all monkeypatched. Tests stay
+fast and deterministic.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _make_sleeper_users(count: int = 12) -> list[dict[str, Any]]:
+    return [
+        {
+            "user_id": f"u{i}",
+            "display_name": f"Manager{i}",
+            "metadata": {"team_name": f"Team{i}"},
+        }
+        for i in range(1, count + 1)
+    ]
+
+
+def _make_rosters(
+    count: int = 12,
+    *,
+    with_history: bool = True,
+) -> list[dict[str, Any]]:
+    rosters = []
+    for i in range(1, count + 1):
+        settings = {
+            "wins": 13 - i if with_history else 0,
+            "losses": i - 1 if with_history else 0,
+            "ties": 0,
+            "fpts": int(1800 - i * 25) if with_history else 0,
+            "fpts_decimal": 50 if with_history else 0,
+            "fpts_against": int(1500 + i * 10) if with_history else 0,
+            "fpts_against_decimal": 25 if with_history else 0,
+        }
+        players = [f"pid-{i}-{j}" for j in range(1, 16)]
+        starters = players[:9]
+        rosters.append(
+            {
+                "roster_id": i,
+                "owner_id": f"u{i}",
+                "settings": settings,
+                "players": players,
+                "starters": starters,
+            }
+        )
+    return rosters
+
+
+def _make_whitelisted_users(count: int = 12) -> list[dict[str, Any]]:
+    # User #1 in this list aligns with ADMIN_ID below.
+    return [
+        {
+            "sleeper_user_id": ADMIN_ID if i == 1 else f"u{i}",
+            "email": f"manager{i}@example.com",
+            "display_name": f"Manager{i}",
+            "sleeper_username": f"manager{i}",
+            "is_active": True,
+            "is_admin": i == 1,
+            "id": f"row-{i}",
+        }
+        for i in range(1, count + 1)
+    ]
+
+
+@pytest.fixture
+def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
+    """Patch all external dependencies of `orchestrator.run` with
+    deterministic stand-ins. Returns a state dict so tests can swap
+    individual seams."""
+    from lambdas.api_admin_ai_review_preseason_trigger import orchestrator
+
+    state: dict[str, Any] = {
+        "writes": [],
+        "metadata_updates": [],
+        "emails_sent": [],
+        "pushes_sent": [],
+        "claude_calls": [],
+        "existing_report": None,
+        "nfl_state": {"season": "2026", "season_type": "pre", "week": 0},
+        "prior_league_id": "PRIOR123",
+        "whitelisted_users": _make_whitelisted_users(),
+        "active_league": {
+            "sleeper_league_id": "LEAGUE_ID",
+            "league_name": "CLT DYNASTY",
+        },
+    }
+
+    monkeypatch.setattr(
+        orchestrator,
+        "get_active_whitelisted_league",
+        lambda: state["active_league"],
+    )
+
+    def _get_league(league_id: str) -> dict[str, Any]:
+        if league_id == "PRIOR123":
+            return {
+                "league_id": "PRIOR123",
+                "name": "CLT DYNASTY (2025)",
+                "season": "2025",
+            }
+        return {
+            "league_id": league_id,
+            "name": "CLT DYNASTY",
+            "previous_league_id": state["prior_league_id"],
+            "season": "2026",
+        }
+
+    monkeypatch.setattr(orchestrator, "get_sleeper_league", _get_league)
+    monkeypatch.setattr(orchestrator, "get_nfl_state", lambda: state["nfl_state"])
+
+    def _users(league_id: str) -> list[dict[str, Any]]:
+        return _make_sleeper_users()
+
+    def _rosters(league_id: str) -> list[dict[str, Any]]:
+        return _make_rosters(with_history=(league_id == "PRIOR123"))
+
+    monkeypatch.setattr(orchestrator, "get_sleeper_league_users", _users)
+    monkeypatch.setattr(orchestrator, "get_sleeper_league_rosters", _rosters)
+
+    def _prior(league_id: str) -> str | None:
+        return state["prior_league_id"]
+
+    monkeypatch.setattr(orchestrator, "get_previous_league_id", _prior)
+
+    monkeypatch.setattr(
+        orchestrator,
+        "get_active_whitelisted_users",
+        lambda: state["whitelisted_users"],
+    )
+
+    # ai_reports_store
+    fake_store = MagicMock()
+
+    def _get_latest(league_id: str, report_type: str):
+        return state["existing_report"]
+
+    def _write_report(*, league_id, report_type, period, body_markdown, metadata):
+        item = {
+            "pk": f"LEAGUE#{league_id}",
+            "sk": f"REPORT#{report_type}#{period}",
+            "league_id": league_id,
+            "report_type": report_type,
+            "period": period,
+            "body_markdown": body_markdown,
+            "metadata": metadata,
+            "created_at": "2026-08-30T15:00:00Z",
+        }
+        state["writes"].append(item)
+        state["existing_report"] = item
+        return item
+
+    def _update_metadata(*, league_id, report_type, period, partial):
+        state["metadata_updates"].append(
+            {
+                "league_id": league_id,
+                "report_type": report_type,
+                "period": period,
+                "partial": partial,
+            }
+        )
+        return {}
+
+    fake_store.get_latest = _get_latest
+    fake_store.write_report = _write_report
+    fake_store.update_metadata = _update_metadata
+    monkeypatch.setattr(orchestrator, "ai_reports_store", fake_store)
+
+    # claude_helper
+    def _generate(
+        *,
+        prompt: str,
+        system: Any,
+        model: str,
+        max_tokens: int,
+        return_usage: bool = False,
+    ):
+        state["claude_calls"].append(
+            {
+                "prompt": prompt,
+                "system": system,
+                "model": model,
+                "max_tokens": max_tokens,
+                "return_usage": return_usage,
+            }
+        )
+        usage = {
+            "input_tokens": 4200,
+            "output_tokens": 2400,
+            "cache_read_input_tokens": 3800,
+            "cache_creation_input_tokens": 400,
+        }
+        text = (
+            "# Preseason Review\n\n## Manager1\n\nLast year was a disaster.\n"
+        )
+        if return_usage:
+            return text, usage
+        return text
+
+    fake_claude = MagicMock()
+    fake_claude.generate = _generate
+    monkeypatch.setattr(orchestrator, "claude_helper", fake_claude)
+
+    # SES + SNS
+    def _send_emails(tasks: list[tuple[str, str, str, str]]):
+        state["emails_sent"].extend(tasks)
+        return len(tasks), 0
+
+    def _send_push(user_ids, title, body, category=None, data=None):
+        state["pushes_sent"].append(
+            {
+                "user_ids": list(user_ids),
+                "title": title,
+                "body": body,
+                "category": category,
+                "data": data,
+            }
+        )
+        return len(user_ids), 0
+
+    monkeypatch.setattr(orchestrator, "send_emails_concurrently", _send_emails)
+    monkeypatch.setattr(orchestrator, "send_push_to_users", _send_push)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorIdempotency:
+    def test_existing_report_with_force_false_raises(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+        from lambdas.common.errors import ReportAlreadyExistsError
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": "LEAGUE_ID",
+            "report_type": "preseason",
+            "period": "2026-PRESEASON",
+            "created_at": "2026-08-30T00:00:00Z",
+        }
+
+        with pytest.raises(ReportAlreadyExistsError):
+            run(dry_run=True, force=False)
+
+    def test_existing_report_with_force_true_overwrites(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": "LEAGUE_ID",
+            "report_type": "preseason",
+            "period": "2026-PRESEASON",
+            "created_at": "2026-08-30T00:00:00Z",
+        }
+
+        result = run(dry_run=True, force=True)
+        assert result["status"] == "dry_run_sent"
+        assert len(patched_orchestrator["writes"]) == 1
+
+    def test_consecutive_writes_with_force_false_still_409(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+        from lambdas.common.errors import ReportAlreadyExistsError
+
+        # First write goes through.
+        first = run(dry_run=True, force=False)
+        assert first["status"] == "dry_run_sent"
+        assert len(patched_orchestrator["writes"]) == 1
+        # Second invocation with force=false now sees the existing row.
+        with pytest.raises(ReportAlreadyExistsError):
+            run(dry_run=True, force=False)
+        assert len(patched_orchestrator["writes"]) == 1
+
+
+class TestOrchestratorPreFlight:
+    def test_regular_season_underway_raises(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+        from lambdas.common.errors import PreseasonWindowPassedError
+
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "regular",
+            "week": 3,
+        }
+        with pytest.raises(PreseasonWindowPassedError) as excinfo:
+            run(dry_run=True, force=False)
+        # The error carries the NFL season + season_type for the
+        # 412 response body.
+        assert excinfo.value.details["season_type"] == "regular"
+        assert excinfo.value.details["nfl_season"] == "2026"
+        # No write should have happened.
+        assert patched_orchestrator["writes"] == []
+
+    def test_postseason_raises(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+        from lambdas.common.errors import PreseasonWindowPassedError
+
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "post",
+            "week": 19,
+        }
+        with pytest.raises(PreseasonWindowPassedError):
+            run(dry_run=True, force=False)
+
+    def test_off_season_is_allowed(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "off",
+            "week": 0,
+        }
+        result = run(dry_run=True, force=False)
+        assert result["status"] == "dry_run_sent"
+
+
+class TestOrchestratorDelivery:
+    def test_dry_run_delivers_to_admin_only(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+
+        assert result["delivery_count"] == 1
+        # One email, addressed to the admin.
+        assert len(patched_orchestrator["emails_sent"]) == 1
+        recipient, subject, _html, _text = patched_orchestrator["emails_sent"][0]
+        assert recipient == "manager1@example.com"
+        assert subject.startswith("[DRY RUN]")
+        # Exactly one push call, targeting only the admin sleeper_user_id.
+        assert len(patched_orchestrator["pushes_sent"]) == 1
+        push = patched_orchestrator["pushes_sent"][0]
+        assert push["user_ids"] == [ADMIN_ID]
+        assert push["title"].startswith("[DRY RUN]")
+        # Dry-run path does NOT set broadcast_at.
+        assert patched_orchestrator["metadata_updates"] == []
+
+    def test_broadcast_delivers_to_all_twelve(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=False, force=True)
+
+        assert result["delivery_count"] == 12
+        assert len(patched_orchestrator["emails_sent"]) == 12
+        for _r, subject, _h, _t in patched_orchestrator["emails_sent"]:
+            assert "[DRY RUN]" not in subject
+        push = patched_orchestrator["pushes_sent"][0]
+        assert len(push["user_ids"]) == 12
+        assert push["title"] == "Your preseason AI review is in"
+        # broadcast_at stamped.
+        assert any(
+            "broadcast_at" in u["partial"]
+            for u in patched_orchestrator["metadata_updates"]
+        )
+
+
+class TestOrchestratorReportShape:
+    def test_metadata_carries_model_prompt_version_tokens(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(
+            dry_run=True,
+            force=False,
+            created_by_user_id="caller-x",
+        )
+        write = patched_orchestrator["writes"][0]
+        meta = write["metadata"]
+        assert meta["model"] == "claude-haiku-4-5"
+        assert meta["prompt_version"].startswith("f2-preseason-")
+        assert meta["dry_run"] is True
+        assert meta["force"] is False
+        assert meta["nfl_season"] == "2026"
+        assert meta["nfl_season_type"] == "pre"
+        assert meta["prior_league_id"] == "PRIOR123"
+        assert meta["created_by_user_id"] == "caller-x"
+        assert meta["token_usage"]["input_tokens"] == 4200
+        assert meta["token_usage"]["output_tokens"] == 2400
+        assert meta["token_usage"]["cache_read_input_tokens"] == 3800
+        # Result also exposes the same usage dict for the API response.
+        assert result["token_usage"]["output_tokens"] == 2400
+        assert result["model"] == "claude-haiku-4-5"
+
+    def test_write_uses_preseason_period(self, patched_orchestrator) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        run(dry_run=True, force=False)
+        write = patched_orchestrator["writes"][0]
+        assert write["report_type"] == "preseason"
+        assert write["period"] == "2026-PRESEASON"
+
+    def test_claude_called_with_two_block_system_payload(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        run(dry_run=True, force=False)
+        call = patched_orchestrator["claude_calls"][0]
+        system = call["system"]
+        assert isinstance(system, list)
+        assert len(system) == 2
+        for block in system:
+            assert block["type"] == "text"
+            assert block["cache_control"] == {"type": "ephemeral"}
+        # User prompt contains the task footer.
+        assert "## Your task" in call["prompt"]
+        # All 12 manager roster headers appear in roster_id order.
+        for i in range(1, 13):
+            assert f"Roster #{i}" in call["prompt"]
+        assert call["prompt"].index("Roster #1") < call["prompt"].index(
+            "Roster #12"
+        )
+
+    def test_prior_standings_failure_is_non_blocking(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import orchestrator
+
+        # Force prior-season rosters call to blow up, current league
+        # call still succeeds.
+        original = orchestrator.get_sleeper_league_rosters
+
+        def _fail_on_prior(league_id: str):
+            if league_id == "PRIOR123":
+                raise RuntimeError("Sleeper hiccup")
+            return original(league_id)
+
+        monkeypatch.setattr(
+            orchestrator, "get_sleeper_league_rosters", _fail_on_prior
+        )
+        result = orchestrator.run(dry_run=True, force=False)
+        assert result["status"] == "dry_run_sent"
+        # User prompt fell back to the no-standings note.
+        call = patched_orchestrator["claude_calls"][0]
+        assert "Prior season standings unavailable" in call["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer tests
+# ---------------------------------------------------------------------------
+
+
+def _api_event(*, sleeper_user_id: str | None = ADMIN_ID, body: dict | None = None) -> dict:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "POST",
+        "path": "/admin/ai-review-preseason-trigger",
+        "headers": headers,
+        "body": __import__("json").dumps(body or {}),
+    }
+
+
+class TestHandler:
+    def test_403_when_not_admin(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+        from lambdas.common.admin_gate import NotAdmin
+
+        def _raise_not_admin(event, body):
+            raise NotAdmin("not authorized")
+
+        monkeypatch.setattr(h, "require_admin", _raise_not_admin)
+
+        response = h.handler(
+            _api_event(body={"dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 403
+        import json
+
+        body = json.loads(response["body"])
+        assert body["Success"] is False
+
+    def test_409_when_existing_report(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": "LEAGUE_ID",
+            "report_type": "preseason",
+            "period": "2026-PRESEASON",
+            "created_at": "2026-08-30T00:00:00Z",
+        }
+
+        response = h.handler(
+            _api_event(body={"dry_run": True, "force": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 409
+        import json
+
+        body = json.loads(response["body"])
+        assert body["error"] == "already_generated"
+        assert body["existing"]["period"] == "2026-PRESEASON"
+
+    def test_412_when_regular_season_started(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "regular",
+            "week": 4,
+        }
+
+        response = h.handler(
+            _api_event(body={"dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 412
+        import json
+
+        body = json.loads(response["body"])
+        assert body["error"] == "preseason_window_passed"
+        assert body["season_type"] == "regular"
+        assert body["nfl_season"] == "2026"
+
+    def test_200_dry_run_single_recipient(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+
+        response = h.handler(
+            _api_event(body={"dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        import json
+
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["dry_run"] is True
+        assert body["delivery_count"] == 1
+        assert body["model"] == "claude-haiku-4-5"
+
+    def test_200_broadcast_all_twelve(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+
+        response = h.handler(
+            _api_event(body={"dry_run": False, "force": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        import json
+
+        body = json.loads(response["body"])
+        assert body["dry_run"] is False
+        assert body["delivery_count"] == 12
+
+    def test_defaults_dry_run_true_force_false(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+
+        response = h.handler(_api_event(body={}), context=None)
+        assert response["statusCode"] == 200
+        import json
+
+        body = json.loads(response["body"])
+        # Safe defaults: dry-run on.
+        assert body["dry_run"] is True

--- a/tests/test_preseason_prompts.py
+++ b/tests/test_preseason_prompts.py
@@ -1,0 +1,236 @@
+"""
+Tests for `api_admin_ai_review_preseason_trigger.prompts`.
+
+Locks the prompt structure that F2 sends to Anthropic — drift in
+either system block or in the user prompt body would land badly on
+Claude's output, so these are intentionally noisy.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lambdas.api_admin_ai_review_preseason_trigger.prompts import (
+    PROMPT_VERSION,
+    SYSTEM_PROMPT_LORE,
+    SYSTEM_PROMPT_TONE,
+    build_system_blocks,
+    build_user_prompt,
+)
+from lambdas.common.constants import AI_REVIEW_PRESEASON_PROMPT_VERSION
+from lambdas.common.league_lore import LEAGUE_LORE
+
+
+class TestSystemBlocks:
+    def test_returns_two_blocks(self) -> None:
+        blocks = build_system_blocks()
+        assert len(blocks) == 2
+
+    def test_both_blocks_are_text_with_ephemeral_cache(self) -> None:
+        for block in build_system_blocks():
+            assert block["type"] == "text"
+            assert block["cache_control"] == {"type": "ephemeral"}
+            assert isinstance(block["text"], str)
+            assert block["text"].strip(), "system block text is empty"
+
+    def test_block_one_re_anchored_on_preseason(self) -> None:
+        blocks = build_system_blocks()
+        text = blocks[0]["text"]
+        assert text == SYSTEM_PROMPT_TONE
+        # The preseason-tuned anchors must appear.
+        for phrase in [
+            "preseason",
+            "year-in-review",
+            "outlook",
+        ]:
+            assert phrase in text, f"missing phrase: {phrase!r}"
+
+    def test_block_one_keeps_safety_rails_verbatim(self) -> None:
+        text = build_system_blocks()[0]["text"]
+        # Same safety rails as F1 — must survive any preseason edit.
+        for phrase in [
+            "Safety rails",
+            "No slurs",
+            "Do NOT invent NFL news",
+            "PG-13",
+        ]:
+            assert phrase in text, f"missing safety phrase: {phrase!r}"
+
+    def test_block_two_is_the_shared_lore_block(self) -> None:
+        blocks = build_system_blocks()
+        lore = blocks[1]["text"]
+        # SYSTEM_PROMPT_LORE re-exports the shared lore text — both
+        # should match the shared `lore_prompt.LORE_TEXT` snapshot.
+        from lambdas.common.lore_prompt import LORE_TEXT
+
+        assert lore == LORE_TEXT
+        assert lore == SYSTEM_PROMPT_LORE
+
+    def test_block_two_contains_all_twelve_managers(self) -> None:
+        lore = build_system_blocks()[1]["text"]
+        for uid, profile in LEAGUE_LORE.items():
+            assert uid in lore, f"missing user_id in lore: {uid}"
+            assert profile.display_name in lore, (
+                f"missing display_name in lore: {profile.display_name}"
+            )
+
+    def test_prompt_version_constant_is_pinned(self) -> None:
+        # Tests + metadata writes both pin against this — keep it
+        # locked to the constants module's value.
+        assert PROMPT_VERSION == AI_REVIEW_PRESEASON_PROMPT_VERSION
+        assert PROMPT_VERSION.startswith("f2-preseason-")
+
+
+class TestBuildUserPrompt:
+    def _sample_team(
+        self,
+        *,
+        roster_id: int,
+        manager: str,
+        player_count: int = 15,
+        with_prior: bool = True,
+    ) -> dict:
+        player_ids = [f"pid-{roster_id}-{i}" for i in range(1, player_count + 1)]
+        starters = player_ids[:9]
+        prior_finish = None
+        if with_prior:
+            prior_finish = {
+                "rank": roster_id,
+                "wins": 13 - roster_id,
+                "losses": roster_id - 1,
+                "ties": 0,
+                "points_for": 1800.0 - roster_id * 25,
+            }
+        return {
+            "roster_id": roster_id,
+            "user_id": f"u{roster_id}",
+            "manager_display_name": manager,
+            "team_name": f"{manager}'s Team",
+            "player_ids": player_ids,
+            "starters": starters,
+            "player_count": len(player_ids),
+            "prior_finish": prior_finish,
+        }
+
+    def _sample_standings(self, count: int = 12) -> list[dict]:
+        return [
+            {
+                "rank": i,
+                "user_id": f"u{i}",
+                "manager_display_name": f"Manager{i}",
+                "team_name": f"Team{i}",
+                "wins": 13 - i,
+                "losses": i - 1,
+                "ties": 0,
+                "points_for": 1800.0 - i * 25,
+                "points_against": 1500.0 + i * 10,
+                "playoff_note": "made the playoffs" if i <= 4 else "",
+            }
+            for i in range(1, count + 1)
+        ]
+
+    def test_includes_final_standings_header(self) -> None:
+        prompt = build_user_prompt(
+            league_name="CLT DYNASTY",
+            season="2026",
+            team_rosters=[],
+            prior_standings=self._sample_standings(),
+        )
+        assert "## Final 2025 Standings" in prompt
+
+    def test_includes_all_twelve_teams_in_roster_id_order(self) -> None:
+        teams = [
+            self._sample_team(roster_id=i, manager=f"Manager{i}")
+            for i in range(1, 13)
+        ]
+        prompt = build_user_prompt(
+            league_name="CLT DYNASTY",
+            season="2026",
+            team_rosters=teams,
+            prior_standings=self._sample_standings(),
+        )
+        # Each manager's roster header appears.
+        for i in range(1, 13):
+            assert f"Roster #{i}" in prompt
+            assert f"Manager{i}" in prompt
+        # Roster #1 comes before Roster #12.
+        assert prompt.index("Roster #1") < prompt.index("Roster #12")
+        # Twelve H2 headers expected — one per team.
+        # (Two H2s come from headings sections, one for standings, one
+        # for rosters, one for task — assert team H3 count.)
+        h3_count = sum(
+            1 for line in prompt.splitlines() if line.startswith("### Roster #")
+        )
+        assert h3_count == 12
+
+    def test_each_team_renders_player_ids_in_starters_and_bench(self) -> None:
+        team = self._sample_team(
+            roster_id=1, manager="Manager1", player_count=15
+        )
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026",
+            team_rosters=[team],
+            prior_standings=None,
+        )
+        # Starters line shows 9 ids, bench line shows the remainder.
+        for pid in team["starters"]:
+            assert pid in prompt
+        bench_ids = [
+            pid for pid in team["player_ids"] if pid not in set(team["starters"])
+        ]
+        for pid in bench_ids:
+            assert pid in prompt
+        assert "Roster size: 15" in prompt
+
+    def test_team_header_includes_prior_year_record_when_available(self) -> None:
+        team = self._sample_team(
+            roster_id=1, manager="Manager1", with_prior=True
+        )
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026",
+            team_rosters=[team],
+            prior_standings=None,
+        )
+        # Header bears the last-year record + PF.
+        assert "last year: #1 / 12-0 / 1775.0 PF" in prompt
+
+    def test_missing_prior_standings_includes_fallback_text(self) -> None:
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026",
+            team_rosters=[],
+            prior_standings=None,
+        )
+        assert "Prior season standings unavailable" in prompt
+
+    def test_empty_team_rosters_includes_fallback_text(self) -> None:
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026",
+            team_rosters=[],
+            prior_standings=None,
+        )
+        assert "No current rosters available" in prompt
+
+    def test_contains_task_footer(self) -> None:
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026",
+            team_rosters=[],
+            prior_standings=None,
+        )
+        assert "## Your task" in prompt
+        assert "roster_id ascending" in prompt
+        assert "Don't invent" in prompt
+
+    def test_non_numeric_season_falls_back_for_prior_year_label(self) -> None:
+        # Backend may receive "2026-PRESEASON" as the season string in
+        # weird cases — _prior_year_label should not crash.
+        prompt = build_user_prompt(
+            league_name="CLT",
+            season="2026-PRESEASON",
+            team_rosters=[],
+            prior_standings=None,
+        )
+        assert "## Final the prior season Standings" in prompt


### PR DESCRIPTION
## Summary

Backend portion of [AI Review F2 — Preseason Blast](../../xomper-ios/blob/main/docs/features/ai-review/f2-preseason/PLAN.md). Adds a new admin-triggered preseason AI Review pipeline that mirrors F1's post-draft trigger structure, plus refactors the shared lore block out of F1 into `lambdas/common/lore_prompt.py` so both pipelines (and the eventual F3 weekly recap) share a single source of truth.

Tracks Xomware/xomper-ios#79.

### Lambda
- **New dir**: `lambdas/api_admin_ai_review_preseason_trigger/` — `__init__.py`, `handler.py`, `orchestrator.py`, `prompts.py`
- **Route**: `POST /admin/ai-review-preseason-trigger` (provisioned by infra PR Xomware/xomper-infrastructure#105 — **lambda is non-functional until that PR is merged + applied**)
- **Body**: same as F1 — `{ dry_run: bool = true, force: bool = false }`
- **Response**: reuses F1's `AIReviewTriggerResponse` envelope — `{ Success, status, report, dry_run, delivery_count, model, token_usage }`

### Differences from F1

| Concern | F1 (postDraft) | F2 (preseason) |
|---|---|---|
| `report_type` | `"postDraft"` | `"preseason"` |
| `period` | `"2026"` | `"2026-PRESEASON"` |
| Pre-flight | Sleeper draft `status == "complete"` → 412 `draft_not_complete` | NFL state `season_type in {pre, off}` → 412 `preseason_window_passed` |
| Data inputs | Draft picks + current rosters/users + prior standings | Current rosters/users + prior rosters/users (no picks) |
| Player names | Resolved via pick metadata | Skipped — raw `player_id` strings in v1 |
| Prompt block 1 | Tone re-anchored on "post-draft grade" | Re-anchored on "year-in-review + outlook" — safety rails verbatim from F1 |
| `max_tokens` | 4000 | 6000 (12 sections × ~400 tokens + intro/closer) |

### Lore-block refactor (yes)

Lore rendering moved from `api_admin_ai_review_postdraft_trigger/prompts.py` into a new `lambdas/common/lore_prompt.py` with:
- `render_league_lore_text() -> str` — pure renderer over `LEAGUE_LORE`
- `build_lore_block() -> dict` — cache-controlled Anthropic system block
- `LORE_TEXT` — module-level snapshot

F1's `prompts.py` keeps `SYSTEM_PROMPT_LORE` as a re-export so existing tests + back-compat hold. F2's `prompts.py` imports the same shared helper. Net effect: the ~3k-token lore payload is now a single source of truth across F1 + F2 (and ready for F3).

### Token-usage estimate per preseason generation

Per the F2 plan + observed F1 numbers:
- Input: ~5k tokens total (~3.5k cached lore block + ~500 cached tone block + ~1k user prompt). Cold-cache: ~$0.005; warm-cache: ~$0.001.
- Output: ~5k tokens (12 manager sections × ~400 tokens + intro + closer). ~$0.020.
- **Per generation: ~$0.020–$0.025 once cache is warm.**
- **Expected F2 cycle (2–3 dry-runs + 1 broadcast): ~$0.10**, well under the $0.50 cycle ceiling.

### Note on infra dependency

This lambda will return 502 (or be entirely unroutable) until Xomware/xomper-infrastructure#105 lands and `terraform apply` provisions the new `/admin/ai-review-preseason-trigger` route + lambda function. Backend deploy pipeline will pick the function up automatically once the stub exists.

## Test plan

- [x] `tests/test_preseason_prompts.py` — 15 tests: 2 ephemeral blocks, preseason re-anchor phrases, safety rails verbatim, lore matches shared `LORE_TEXT`, all 12 managers + user_ids in lore, `PROMPT_VERSION` pinned, user prompt renders 12 rosters + standings + task footer
- [x] `tests/test_api_admin_ai_review_preseason_trigger.py` — 18 tests covering:
  - 403 when caller isn't admin
  - 409 with `error=already_generated` when report exists + `force=false`
  - 412 with `error=preseason_window_passed` when NFL `season_type=regular` or `post`
  - 200 + `delivery_count=1` for `dry_run=true`
  - 200 + `delivery_count=12` for `dry_run=false, force=true`
  - Defaults (`dry_run=true, force=false` when body is empty)
  - Idempotency: second `force=false` call still 409s
  - `off` season type also allowed (true off-season window)
  - Metadata carries `model`, `prompt_version=f2-preseason-...`, `nfl_season`, `nfl_season_type`, `prior_league_id`, `created_by_user_id`, `token_usage`
  - Write hits `report_type="preseason"`, `period="2026-PRESEASON"`
  - Claude called with `system: list[dict]` of length 2, both ephemeral; user prompt contains all 12 rosters in `roster_id` asc order + task footer
  - Prior-standings fetch failure is non-blocking; user prompt falls back to "Prior season standings unavailable"
- [x] F1 suites still green after the lore refactor: `test_postdraft_prompts.py` (13 passed) and `test_api_admin_ai_review_postdraft_trigger.py` (20 passed)
- [x] Full suite: **169 passed** locally
- [ ] Smoke test post-deploy: `curl -X POST -H "Authorization: Bearer <admin-jwt>" -d '{"dry_run":true,"force":false}' $API/admin/ai-review-preseason-trigger` → 200, dry-run email lands, Dynamo row at `LEAGUE#<id>` / `REPORT#preseason#2026-PRESEASON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)