### PR TITLE
feat(ai-review): backfill support — target_year for postDraft + seasons_back for weekly + driver script

### DIFF
--- a/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
@@ -13,13 +13,20 @@ Body:
     "sleeper_user_id": "abc123",     // required — admin gate identity
     "email": "user@example.com",     // optional fallback identity
     "dry_run": true,                 // optional, default true
-    "force": false                   // optional, default false
+    "force": false,                  // optional, default false
+    "target_year": 2024              // optional — backfill mode: walk
+                                     //   previous_league_id from active
+                                     //   league until season == str(year),
+                                     //   then generate against THAT draft.
+                                     //   Default None = current draft.
 }
 
 Behavior:
 - 200 + body on success (delivery counts + token usage + report row).
 - 400 on bad input.
 - 403 when the caller is not an admin.
+- 404 when target_year is set but no historical league with that
+  season is reachable via previous_league_id.
 - 409 when a report already exists and `force=false`.
 - 412 when the Sleeper draft is not yet complete.
 - 502 when Anthropic / Sleeper external calls fail terminally.
@@ -61,6 +68,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     dry_run = _coerce_bool(body.get("dry_run"), default=True)
     force = _coerce_bool(body.get("force"), default=False)
+    target_year = _coerce_int(body.get("target_year"))
     created_by = admin_user.get("sleeper_user_id") or admin_user.get("id")
 
     try:
@@ -68,6 +76,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             dry_run=dry_run,
             force=force,
             created_by_user_id=created_by,
+            target_year=target_year,
         )
     except ReportAlreadyExistsError as err:
         err.log_error()
@@ -106,8 +115,21 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "delivery_count": result["delivery_count"],
             "model": result["model"],
             "token_usage": result["token_usage"],
+            "period": result.get("period"),
+            "target_year": result.get("target_year"),
         }
     )
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Cast API GW body integers (which sometimes arrive as strings)
+    to int. Returns None on failure or when omitted."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def _coerce_bool(value: Any, *, default: bool) -> bool:

--- a/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
@@ -41,6 +41,7 @@ from lambdas.common.errors import (
     ReportAlreadyExistsError,
 )
 from lambdas.common.logger import get_logger
+from lambdas.common.season_resolver import resolve_league_by_year
 from lambdas.common.ses_helper import send_emails_concurrently
 from lambdas.common.sleeper_helper import (
     get_previous_league_id,
@@ -68,7 +69,6 @@ PUSH_TITLE_BROADCAST = "Your post-draft AI review is in"
 PUSH_BODY_BROADCAST = "Tap to see how your draft graded out."
 PUSH_TITLE_DRY_RUN = "[DRY RUN] Post-draft AI review ready"
 PUSH_BODY_DRY_RUN = "Tap to preview before broadcasting."
-DEEP_LINK = f"xomper://ai-review/post-draft/{AI_REVIEW_POSTDRAFT_PERIOD}"
 PUSH_CATEGORY = "AI_REVIEW"
 
 
@@ -77,6 +77,7 @@ def run(
     dry_run: bool = True,
     force: bool = False,
     created_by_user_id: str | None = None,
+    target_year: int | None = None,
 ) -> dict[str, Any]:
     """Drive the post-draft AI Review generation + delivery.
 
@@ -90,16 +91,25 @@ def run(
             When True, overwrites the existing row.
         created_by_user_id: Sleeper user_id of the admin who fired the
             trigger. Stamped into `metadata` for auditability.
+        target_year: When None (default), uses the active league's
+            current draft and writes period=`AI_REVIEW_POSTDRAFT_PERIOD`.
+            When an int (e.g. 2024), walks `previous_league_id` from
+            the active league until a league with `season ==
+            str(target_year)` is found, then runs the entire pipeline
+            against THAT league's draft + rosters + users + prior
+            standings. Period becomes `str(target_year)`. Used for
+            historical backfill.
 
     Returns:
         Dict carrying `report_id`, `dry_run`, `delivery_count`,
-        `model`, `token_usage`, `status`, `existing`. The handler
-        wraps this for the API response.
+        `model`, `token_usage`, `status`, `existing`, `target_year`,
+        `period`. The handler wraps this for the API response.
 
     Raises:
         DraftNotCompleteError: Sleeper draft status != "complete".
         ReportAlreadyExistsError: Existing row + force=False.
-        NotFoundError: No active whitelisted league configured.
+        NotFoundError: No active whitelisted league configured, or
+            `target_year` not reachable via previous_league_id.
         ClaudeAPIError: Anthropic call failed after retries.
     """
     league_row = get_active_whitelisted_league()
@@ -110,12 +120,12 @@ def run(
             function="run",
             resource="whitelisted_leagues",
         )
-    league_id = (
+    active_league_id = (
         league_row.get("sleeper_league_id")
         or league_row.get("league_id")
         or ""
     )
-    if not league_id:
+    if not active_league_id:
         raise NotFoundError(
             message="Active league row is missing sleeper_league_id",
             handler="notif_ai_review_postdraft",
@@ -123,13 +133,51 @@ def run(
             resource="whitelisted_leagues",
         )
 
-    period = AI_REVIEW_POSTDRAFT_PERIOD
+    # Resolve the league to operate against. For target_year backfill
+    # we walk the previous_league_id chain to the matching season; the
+    # report is still keyed under the ACTIVE league_id (one report row
+    # per (league_id, type, period)) but every Sleeper fetch is
+    # relative to the resolved historical league.
+    if target_year is not None:
+        league = resolve_league_by_year(
+            active_league_id,
+            target_year,
+            league_fetcher=get_sleeper_league,
+        )
+        league_id = active_league_id
+        operating_league_id = (
+            league.get("league_id") or str(league.get("league_id") or "")
+        )
+        if not operating_league_id:
+            raise NotFoundError(
+                message=(
+                    f"Resolved historical league for target_year="
+                    f"{target_year} is missing a league_id"
+                ),
+                handler="notif_ai_review_postdraft",
+                function="run",
+                resource="previous_league_id",
+            )
+        period = str(target_year)
+        log.info(
+            f"notif_ai_review_postdraft: backfill target_year="
+            f"{target_year} -> historical league_id="
+            f"{operating_league_id}"
+        )
+    else:
+        league = get_sleeper_league(active_league_id)
+        league_id = active_league_id
+        operating_league_id = active_league_id
+        period = AI_REVIEW_POSTDRAFT_PERIOD
 
-    # 1. Idempotency
+    # 1. Idempotency — keyed by (active league_id, "postDraft", period)
     existing = ai_reports_store.get_latest(league_id, REPORT_TYPE)
-    if existing and not force:
+    if existing and not force and existing.get("period") == period:
         raise ReportAlreadyExistsError(
-            message="A post-draft report already exists for this league",
+            message=(
+                f"A post-draft report already exists for this league "
+                f"and period {period}"
+            ),
             existing={
                 "league_id": existing.get("league_id"),
                 "report_type": existing.get("report_type"),
@@ -139,13 +187,12 @@ def run(
         )
 
     # 2. Pre-flight: confirm draft is complete
-    league = get_sleeper_league(league_id)
     draft_id = league.get("draft_id")
     if not draft_id:
         raise DraftNotCompleteError(
             message=(
-                f"League {league_id} has no draft_id — Sleeper draft "
-                "not provisioned yet"
+                f"League {operating_league_id} has no draft_id — "
+                "Sleeper draft not provisioned yet"
             ),
             draft_status=None,
         )
@@ -158,12 +205,13 @@ def run(
             draft_status=draft_status,
         )
 
-    # 3. Load data
+    # 3. Load data — all relative to the operating (possibly
+    # historical) league.
     picks = get_sleeper_draft_picks(draft_id)
-    sleeper_users = get_sleeper_league_users(league_id)
-    rosters = get_sleeper_league_rosters(league_id)
+    sleeper_users = get_sleeper_league_users(operating_league_id)
+    rosters = get_sleeper_league_rosters(operating_league_id)
 
-    prior_league_id = get_previous_league_id(league_id)
+    prior_league_id = get_previous_league_id(operating_league_id)
     prior_standings: list[dict[str, Any]] = []
     if prior_league_id:
         try:
@@ -210,6 +258,8 @@ def run(
         "token_usage": token_usage,
         "draft_id": str(draft_id),
         "broadcast_at": None,
+        "target_year": target_year,
+        "operating_league_id": operating_league_id,
     }
     if created_by_user_id:
         metadata["created_by_user_id"] = created_by_user_id
@@ -255,6 +305,8 @@ def run(
         "delivery_count": delivery_count,
         "model": AI_REVIEW_DEFAULT_MODEL,
         "token_usage": token_usage,
+        "period": period,
+        "target_year": target_year,
     }
 
 
@@ -424,6 +476,7 @@ def _deliver(
         return 0
 
     period_label = f"Post-Draft {period}"
+    deep_link = f"xomper://ai-review/post-draft/{period}"
     email_tasks: list[tuple[str, str, str, str]] = []
     push_user_ids: list[str] = []
 
@@ -469,7 +522,7 @@ def _deliver(
             title,
             body,
             PUSH_CATEGORY,
-            {"url": DEEP_LINK, "period": period},
+            {"url": deep_link, "period": period},
         )
 
     return len(recipients)

--- a/lambdas/api_admin_ai_review_weekly_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_weekly_trigger/handler.py
@@ -15,7 +15,15 @@ Body:
     "week": 4,                        // optional — defaults to current
     "dry_run": true,                 // optional, default true
     "force": false,                  // optional, default false
-    "use_previous_season": false     // optional, default false
+    "seasons_back": 0,               // optional, default 0 — walk
+                                     //   previous_league_id N times
+                                     //   from the active league
+                                     //   before fetching matchups.
+                                     //   1 = prior season, 2 = two
+                                     //   seasons ago, etc.
+    "use_previous_season": false     // DEPRECATED — alias for
+                                     //   seasons_back=1. Logs a
+                                     //   warning when used.
 }
 
 Behavior:
@@ -68,6 +76,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     week = _coerce_int(body.get("week"))
     dry_run = _coerce_bool(body.get("dry_run"), default=True)
     force = _coerce_bool(body.get("force"), default=False)
+    seasons_back_raw = _coerce_int(body.get("seasons_back"))
+    seasons_back = seasons_back_raw if seasons_back_raw is not None else 0
+    # Back-compat alias — forwarded to the orchestrator which logs
+    # a deprecation warning when truthy AND seasons_back==0.
     use_previous_season = _coerce_bool(
         body.get("use_previous_season"), default=False
     )
@@ -78,6 +90,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             week=week,
             dry_run=dry_run,
             force=force,
+            seasons_back=seasons_back,
             use_previous_season=use_previous_season,
             created_by_user_id=created_by,
         )
@@ -113,6 +126,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "memory_count_in": result.get("memory_count_in"),
             "memory_count_out": result.get("memory_count_out"),
             "envelope_parsed": result.get("envelope_parsed"),
+            "seasons_back": result.get("seasons_back"),
             "use_previous_season": result.get("use_previous_season"),
         }
     )

--- a/lambdas/common/season_resolver.py
+++ b/lambdas/common/season_resolver.py
@@ -1,0 +1,184 @@
+"""
+Season resolver
+===============
+Shared helpers for walking Sleeper's `previous_league_id` chain
+backwards from the active league.
+
+Used by AI Review F1 (post-draft) + F3 (weekly) to support backfill
+runs against historical seasons. Both lambdas need to:
+
+- Walk back N seasons (`seasons_back=1` -> the prior league),
+- Or walk back until a league with `season == "<year>"` is found
+  (target-year mode).
+
+Returns the resolved Sleeper league dict, or raises `NotFoundError`
+if we ran out of `previous_league_id` links before satisfying the
+request.
+
+Lives in `lambdas/common/` so both F1's orchestrator and F3's
+weekly_orchestrator can import it. The deploy script zips each
+lambda dir in isolation; cross-package imports only survive when
+they originate in the common layer.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from lambdas.common.errors import NotFoundError
+from lambdas.common.logger import get_logger
+from lambdas.common.sleeper_helper import get_sleeper_league as _default_get_league
+
+log = get_logger(__file__)
+
+# Bounded to keep accidental misuse from walking forever. The CLT
+# Dynasty league started in 2022 so 10 hops is generous.
+_MAX_HOPS = 12
+
+# Type alias: caller-injectable league fetcher. Always returns the
+# Sleeper league dict for the given id. Tests / orchestrators pass
+# their already-patched reference so monkeypatch reaches the
+# resolver without needing to also patch this module.
+LeagueFetcher = Callable[[str], dict[str, Any]]
+
+
+def resolve_historical_league(
+    league_id: str,
+    seasons_back: int,
+    *,
+    league_fetcher: LeagueFetcher | None = None,
+) -> dict[str, Any]:
+    """Walk `previous_league_id` exactly `seasons_back` times from
+    the given league, returning the Sleeper league dict at that
+    depth.
+
+    Args:
+        league_id: Active league id to start from.
+        seasons_back: Number of times to follow `previous_league_id`.
+            0 -> return the active league unchanged. 1 -> immediate
+            prior season. Etc. Must be >= 0.
+        league_fetcher: Optional injection point — the function used
+            to load a league by id. Defaults to
+            `sleeper_helper.get_sleeper_league`. Orchestrators pass
+            their already-imported reference so monkeypatched
+            tests resolve correctly.
+
+    Returns:
+        The Sleeper league dict at the requested depth.
+
+    Raises:
+        NotFoundError: When the chain is exhausted before we hit the
+            requested depth (i.e. the league has no further prior
+            seasons linked).
+        ValidationError: Never directly; callers should pre-validate
+            `seasons_back >= 0`.
+    """
+    fetch = league_fetcher or _default_get_league
+
+    if seasons_back < 0:
+        raise NotFoundError(
+            message=(
+                f"seasons_back must be >= 0, got {seasons_back}"
+            ),
+            handler="season_resolver",
+            function="resolve_historical_league",
+            resource="seasons_back",
+        )
+
+    current_id: str | None = league_id
+    current_league: dict[str, Any] = fetch(current_id)
+    hops = 0
+    while hops < seasons_back:
+        if hops >= _MAX_HOPS:
+            raise NotFoundError(
+                message=(
+                    f"Exceeded max hops ({_MAX_HOPS}) while walking "
+                    f"previous_league_id from {league_id}"
+                ),
+                handler="season_resolver",
+                function="resolve_historical_league",
+                resource="previous_league_id",
+            )
+        prev_id = current_league.get("previous_league_id")
+        if prev_id in (None, "", "0"):
+            raise NotFoundError(
+                message=(
+                    f"League {current_league.get('league_id') or current_id} "
+                    f"has no previous_league_id — cannot walk "
+                    f"{seasons_back} season(s) back from {league_id} "
+                    f"(stopped after {hops} hop(s))"
+                ),
+                handler="season_resolver",
+                function="resolve_historical_league",
+                resource="previous_league_id",
+            )
+        current_id = str(prev_id)
+        current_league = fetch(current_id)
+        hops += 1
+
+    return current_league
+
+
+def resolve_league_by_year(
+    league_id: str,
+    target_year: int,
+    *,
+    league_fetcher: LeagueFetcher | None = None,
+) -> dict[str, Any]:
+    """Walk `previous_league_id` from the active league until we hit
+    a league whose `season == str(target_year)`. Returns that league
+    dict.
+
+    Note: this walks BACKWARDS (only). If the active league's
+    `season` is older than `target_year`, no forward chain exists
+    on Sleeper, so we raise `NotFoundError`.
+
+    Args:
+        league_id: Active league id to start from.
+        target_year: Calendar year (e.g. 2024). Matched against
+            Sleeper's `season` field as a string.
+        league_fetcher: Optional injection point — the function used
+            to load a league by id. Defaults to
+            `sleeper_helper.get_sleeper_league`. Orchestrators pass
+            their already-imported reference so monkeypatched
+            tests resolve correctly.
+
+    Returns:
+        The Sleeper league dict for the matching season.
+
+    Raises:
+        NotFoundError: When the chain runs out (no `previous_league_id`)
+            before finding a league with `season == str(target_year)`.
+    """
+    fetch = league_fetcher or _default_get_league
+    target = str(target_year)
+    current_id: str | None = league_id
+    hops = 0
+    while True:
+        if hops >= _MAX_HOPS:
+            raise NotFoundError(
+                message=(
+                    f"Exceeded max hops ({_MAX_HOPS}) while searching "
+                    f"for season={target!r} from {league_id}"
+                ),
+                handler="season_resolver",
+                function="resolve_league_by_year",
+                resource="previous_league_id",
+            )
+        league = fetch(current_id)
+        season = str(league.get("season") or "").strip()
+        if season == target:
+            return league
+        prev_id = league.get("previous_league_id")
+        if prev_id in (None, "", "0"):
+            raise NotFoundError(
+                message=(
+                    f"No league with season={target!r} reachable from "
+                    f"{league_id} via previous_league_id "
+                    f"(stopped at season={season!r} after {hops} hop(s))"
+                ),
+                handler="season_resolver",
+                function="resolve_league_by_year",
+                resource="target_year",
+            )
+        current_id = str(prev_id)
+        hops += 1

--- a/lambdas/common/weekly_orchestrator.py
+++ b/lambdas/common/weekly_orchestrator.py
@@ -58,6 +58,7 @@ from lambdas.common.errors import (
     ValidationError,
 )
 from lambdas.common.logger import get_logger
+from lambdas.common.season_resolver import resolve_historical_league
 from lambdas.common.ses_helper import send_emails_concurrently
 from lambdas.common.sleeper_helper import (
     get_nfl_state,
@@ -97,6 +98,7 @@ def run_weekly(
     week: int | None = None,
     dry_run: bool = True,
     force: bool = False,
+    seasons_back: int = 0,
     use_previous_season: bool = False,
     created_by_user_id: str | None = None,
 ) -> dict[str, Any]:
@@ -111,10 +113,19 @@ def run_weekly(
         force: When False (default), an existing report for this
             (league, "weekly", period) raises
             `ReportAlreadyExistsError`. When True, overwrites.
-        use_previous_season: For dry-run calibration against last
-            year's matchup data. Swaps Sleeper fetches to the prior
-            league via `previous_league_id`. The cron NEVER sets
-            this; only the admin trigger does.
+        seasons_back: How many times to walk `previous_league_id`
+            from the active league. 0 (default) = current season,
+            1 = prior, 2 = two seasons ago, etc. Used for historical
+            backfill. The matchups + rosters + users are all fetched
+            from the resolved historical league, and the period is
+            built from THAT league's `season` field
+            (e.g. `2024W05`). Idempotency keys are still
+            (active league_id, "weekly", historical period).
+        use_previous_season: DEPRECATED alias for `seasons_back=1`.
+            When passed (truthy), maps to seasons_back=1 and logs a
+            deprecation warning. Kept for back-compat with the F3
+            plan + any in-flight clients. New callers should use
+            `seasons_back` instead.
         created_by_user_id: Sleeper user_id of the caller (admin
             trigger) or None (cron). Stamped into metadata for
             auditability.
@@ -122,15 +133,43 @@ def run_weekly(
     Returns:
         Dict carrying `status`, `report`, `dry_run`, `delivery_count`,
         `model`, `token_usage`, `week`, `period`, `memory_count_in`,
-        `memory_count_out`. Both handlers wrap this for their
-        responses.
+        `memory_count_out`, `seasons_back`, `use_previous_season`
+        (back-compat). Both handlers wrap this for their responses.
 
     Raises:
         ReportAlreadyExistsError: Existing row + force=False.
-        NotFoundError: No active whitelisted league configured.
-        ValidationError: Bad week input.
+        NotFoundError: No active whitelisted league configured, or
+            `seasons_back` exceeds the available chain depth.
+        ValidationError: Bad week or seasons_back input.
         ClaudeAPIError: Anthropic call failed after retries.
     """
+    # Back-compat: use_previous_season=True is equivalent to
+    # seasons_back=1. Only honor the alias when the caller didn't
+    # also pass a non-default seasons_back.
+    if use_previous_season:
+        if seasons_back == 0:
+            log.warning(
+                "weekly_orchestrator: `use_previous_season` is "
+                "deprecated; use `seasons_back=1` instead"
+            )
+            seasons_back = 1
+        else:
+            log.warning(
+                "weekly_orchestrator: both `use_previous_season` and "
+                f"`seasons_back={seasons_back}` provided; honoring "
+                "`seasons_back`"
+            )
+
+    if seasons_back < 0:
+        raise ValidationError(
+            message=(
+                f"seasons_back must be >= 0, got {seasons_back}"
+            ),
+            handler="notif_ai_review_weekly",
+            function="run_weekly",
+            field="seasons_back",
+        )
+
     league_row = get_active_whitelisted_league()
     if not league_row:
         raise NotFoundError(
@@ -161,9 +200,10 @@ def run_weekly(
     resolved_week = _resolve_week(week=week, nfl_week=nfl_week_raw)
 
     # --- pre-flight ----------------------------------------------------------
-    # For previous-season dry-runs we deliberately bypass the
-    # season-type gate (calibrating against finished 2025 data).
-    if not use_previous_season:
+    # For backfill against finished seasons we deliberately bypass
+    # the season-type gate (calibrating / archiving against
+    # completed data).
+    if seasons_back == 0:
         if season_type and season_type not in AI_REVIEW_WEEKLY_OK_SEASON_TYPES:
             log.info(
                 f"notif_ai_review_weekly: season_type={season_type!r} "
@@ -183,17 +223,27 @@ def run_weekly(
                 "memory_count_out": 0,
                 "skipped": True,
                 "reason": f"season_type={season_type!r}",
+                "seasons_back": seasons_back,
+                "use_previous_season": seasons_back == 1,
             }
 
     # --- data fetch source league --------------------------------------------
     matchup_league_id = league_id
-    if use_previous_season:
-        prior_id = get_previous_league_id(league_id)
+    if seasons_back > 0:
+        historical_league = resolve_historical_league(
+            league_id,
+            seasons_back,
+            league_fetcher=get_sleeper_league,
+        )
+        prior_id = (
+            historical_league.get("league_id")
+            or str(historical_league.get("league_id") or "")
+        )
         if not prior_id:
             raise NotFoundError(
                 message=(
-                    "use_previous_season=True but the active league "
-                    "has no previous_league_id linked"
+                    f"Resolved historical league for seasons_back="
+                    f"{seasons_back} is missing a league_id"
                 ),
                 handler="notif_ai_review_weekly",
                 function="run_weekly",
@@ -201,8 +251,9 @@ def run_weekly(
             )
         matchup_league_id = prior_id
         log.info(
-            f"notif_ai_review_weekly: dry-run calibration vs "
-            f"previous league {prior_id} (week {resolved_week})"
+            f"notif_ai_review_weekly: backfill seasons_back="
+            f"{seasons_back} -> league {prior_id} (week "
+            f"{resolved_week})"
         )
 
     league = get_sleeper_league(matchup_league_id)
@@ -275,7 +326,10 @@ def run_weekly(
     metadata: dict[str, Any] = {
         "dry_run": dry_run,
         "force": force,
-        "use_previous_season": use_previous_season,
+        "seasons_back": seasons_back,
+        # Back-compat tag — present for any downstream consumers that
+        # read this field. True when seasons_back >= 1.
+        "use_previous_season": seasons_back >= 1,
         "model": AI_REVIEW_DEFAULT_MODEL,
         "prompt_version": AI_REVIEW_WEEKLY_PROMPT_VERSION,
         "token_usage": token_usage,
@@ -380,7 +434,10 @@ def run_weekly(
         "memory_count_in": len(prior_memories),
         "memory_count_out": written_memories,
         "envelope_parsed": parse_ok,
-        "use_previous_season": use_previous_season,
+        "seasons_back": seasons_back,
+        # Back-compat surface so the API response shape stays stable
+        # for clients still reading `use_previous_season`.
+        "use_previous_season": seasons_back >= 1,
     }
 
 

--- a/lambdas/notif_ai_review_weekly/handler.py
+++ b/lambdas/notif_ai_review_weekly/handler.py
@@ -21,8 +21,9 @@ Behavior contract:
   is rarely what we want (a Tuesday afternoon glitch shouldn't
   flap the cron — recovery is via the admin trigger).
 - For testing / backfill, the event may carry `{"week": N,
-  "dry_run": true, "force": true, "use_previous_season": false}` —
-  same shape the admin trigger accepts.
+  "dry_run": true, "force": true, "seasons_back": 0}` — same
+  shape the admin trigger accepts. `use_previous_season` is also
+  accepted as a deprecated alias for `seasons_back=1`.
 """
 from __future__ import annotations
 
@@ -48,6 +49,11 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     week_override = _coerce_int(overrides.get("week"))
     dry_run = _coerce_bool(overrides.get("dry_run"), default=False)
     force = _coerce_bool(overrides.get("force"), default=False)
+    seasons_back_raw = _coerce_int(overrides.get("seasons_back"))
+    seasons_back = seasons_back_raw if seasons_back_raw is not None else 0
+    # Back-compat alias — forwarded to the orchestrator which logs a
+    # deprecation warning when truthy. Default False keeps the cron
+    # call shape stable for existing snapshot tests.
     use_previous_season = _coerce_bool(
         overrides.get("use_previous_season"), default=False
     )
@@ -57,6 +63,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             week=week_override,
             dry_run=dry_run,
             force=force,
+            seasons_back=seasons_back,
             use_previous_season=use_previous_season,
         )
     except Exception as err:  # noqa: BLE001 — cron must not flap

--- a/scripts/backfill_ai_reports.py
+++ b/scripts/backfill_ai_reports.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+AI Review backfill driver
+=========================
+Drives historical post-draft + weekly AI Review generation against
+the deployed admin endpoints. Used once-ish to seed the 2024 + 2025
+report archive (and stress-test the Claude prompts against real
+finished-season data) ahead of the 2026 launch.
+
+This script is OPT-IN and manually run. It never auto-fires from CI
+and never touches infra. Re-runnable (use --force to overwrite
+existing reports; defaults to dry-run mode for safety).
+
+Usage
+-----
+    # Required env vars
+    export XOMPER_API_BASE_URL="https://api.xomper.xomware.com"
+    export XOMPER_ADMIN_JWT="eyJ..."            # JWT from Supabase auth
+    export XOMPER_ADMIN_SLEEPER_USER_ID="..."   # admin sleeper_user_id
+
+    # Dry-run (sends only to Dominick — tone calibration)
+    python3 scripts/backfill_ai_reports.py --dry-run
+
+    # Real backfill (broadcasts to all 12 — only do this once)
+    python3 scripts/backfill_ai_reports.py --no-dry-run --force
+
+    # Just 2024, just postDraft
+    python3 scripts/backfill_ai_reports.py --years 2024 --postdraft-only
+
+    # Just one week
+    python3 scripts/backfill_ai_reports.py --years 2025 --weeks 5
+
+Flags
+-----
+    --years            comma-separated, default "2024,2025"
+    --weeks            comma-separated, default "1-17"
+    --postdraft-only   skip weekly calls
+    --weekly-only      skip post-draft calls
+    --dry-run          send only to Dominick (DEFAULT — safe)
+    --no-dry-run       broadcast to all 12 managers (be sure)
+    --force            overwrite existing reports for this period
+    --sleep            seconds between calls (default 1.0)
+    --timeout          request timeout in seconds (default 300)
+
+Cost estimate
+-------------
+Per the F1 / F3 plans, each Claude Haiku 4.5 call is ~$0.02. For
+2 years x (1 postDraft + ~17 weekly) = ~36 calls, total ~$0.72.
+The script prints a running total as it goes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Any
+
+import requests
+
+# Per-call cost estimate (USD). Conservative — Haiku 4.5 with
+# heavy prompt-cache reuse trends below this in practice.
+COST_PER_CALL_USD = 0.02
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Backfill AI Review reports for past seasons.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    p.add_argument(
+        "--years",
+        default="2024,2025",
+        help="Comma-separated calendar years to backfill (default 2024,2025).",
+    )
+    p.add_argument(
+        "--weeks",
+        default="1-17",
+        help=(
+            "Comma-separated week list or range. Default '1-17' "
+            "covers the full regular season. Use '1-22' to include "
+            "playoffs."
+        ),
+    )
+    p.add_argument(
+        "--postdraft-only",
+        action="store_true",
+        help="Only run post-draft (skip weekly recaps).",
+    )
+    p.add_argument(
+        "--weekly-only",
+        action="store_true",
+        help="Only run weekly recaps (skip post-draft).",
+    )
+    p.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        action="store_true",
+        default=True,
+        help="Send only to the admin (default).",
+    )
+    p.add_argument(
+        "--no-dry-run",
+        dest="dry_run",
+        action="store_false",
+        help="Broadcast to all 12 managers.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing reports for this period.",
+    )
+    p.add_argument(
+        "--sleep",
+        type=float,
+        default=1.0,
+        help="Seconds to sleep between calls (default 1.0).",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        help="Request timeout in seconds (default 300).",
+    )
+    return p.parse_args()
+
+
+def _parse_year_list(raw: str) -> list[int]:
+    out: list[int] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        out.append(int(chunk))
+    return out
+
+
+def _parse_week_list(raw: str) -> list[int]:
+    out: list[int] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if "-" in chunk:
+            lo, hi = chunk.split("-", 1)
+            for w in range(int(lo), int(hi) + 1):
+                out.append(w)
+        else:
+            out.append(int(chunk))
+    return out
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        sys.stderr.write(
+            f"\nERROR: missing required env var {name!r}.\n"
+            f"Set it before running this script:\n"
+            f"    export {name}=...\n\n"
+        )
+        sys.exit(2)
+    return value
+
+
+def _post(
+    *,
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    timeout: int,
+) -> tuple[int, dict[str, Any]]:
+    try:
+        response = requests.post(
+            url, json=body, headers=headers, timeout=timeout
+        )
+    except requests.RequestException as err:
+        return 0, {"_request_error": str(err)}
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"_raw": response.text}
+    return response.status_code, payload
+
+
+def _summary(status: int, payload: dict[str, Any]) -> str:
+    if status == 0:
+        return f"NET FAIL: {payload.get('_request_error')!r}"
+    if status >= 400:
+        msg = (
+            payload.get("Message")
+            or payload.get("message")
+            or payload.get("error")
+            or payload.get("_raw")
+            or ""
+        )
+        return f"HTTP {status} — {str(msg)[:120]}"
+    token_usage = payload.get("token_usage") or {}
+    in_tok = token_usage.get("input_tokens")
+    out_tok = token_usage.get("output_tokens")
+    return (
+        f"OK status={payload.get('status')} "
+        f"period={payload.get('period')} "
+        f"delivery={payload.get('delivery_count')} "
+        f"in={in_tok} out={out_tok}"
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+
+    base_url = _require_env("XOMPER_API_BASE_URL").rstrip("/")
+    jwt = _require_env("XOMPER_ADMIN_JWT")
+    sleeper_user_id = _require_env("XOMPER_ADMIN_SLEEPER_USER_ID")
+
+    years = _parse_year_list(args.years)
+    weeks = _parse_week_list(args.weeks)
+
+    if not years:
+        sys.stderr.write("ERROR: --years produced an empty list\n")
+        return 2
+    if not args.postdraft_only and not weeks:
+        sys.stderr.write("ERROR: --weeks produced an empty list\n")
+        return 2
+
+    headers = {
+        "Authorization": f"Bearer {jwt}",
+        "Content-Type": "application/json",
+        # Both supported by the admin gate — pass both so the call
+        # works regardless of authorizer claim shape on the deployed
+        # API GW.
+        "X-Sleeper-User-Id": sleeper_user_id,
+    }
+
+    postdraft_url = f"{base_url}/admin/ai-review-postdraft-trigger"
+    weekly_url = f"{base_url}/admin/ai-review-weekly-trigger"
+
+    # The "current" active league is the 2026 league. seasons_back for
+    # weekly: 2026 -> 0 hops, 2025 -> 1 hop, 2024 -> 2 hops, etc.
+    # The user can override this by adjusting the year list.
+    def _seasons_back_for(year: int) -> int:
+        current = 2026
+        diff = current - year
+        return max(0, diff)
+
+    total_calls = 0
+    ok_calls = 0
+    print(
+        f"\nBackfill driver — base={base_url} dry_run={args.dry_run} "
+        f"force={args.force}"
+    )
+    print(f"  years={years} weeks={weeks if not args.postdraft_only else '[skipped]'}")
+    print()
+
+    for year in years:
+        # --- POST DRAFT ----
+        if not args.weekly_only:
+            body = {
+                "sleeper_user_id": sleeper_user_id,
+                "dry_run": args.dry_run,
+                "force": args.force,
+                "target_year": year,
+            }
+            print(
+                f"[postDraft {year}] POST {postdraft_url} "
+                f"body={json.dumps({k: v for k, v in body.items() if k != 'sleeper_user_id'})}"
+            )
+            status, payload = _post(
+                url=postdraft_url,
+                body=body,
+                headers=headers,
+                timeout=args.timeout,
+            )
+            total_calls += 1
+            if 200 <= status < 300:
+                ok_calls += 1
+            print(f"  -> {_summary(status, payload)}")
+            time.sleep(args.sleep)
+
+        # --- WEEKLY ----
+        if not args.postdraft_only:
+            sb = _seasons_back_for(year)
+            for week in weeks:
+                body = {
+                    "sleeper_user_id": sleeper_user_id,
+                    "week": week,
+                    "dry_run": args.dry_run,
+                    "force": args.force,
+                    "seasons_back": sb,
+                }
+                print(
+                    f"[weekly {year}W{week:02d}] POST {weekly_url} "
+                    f"seasons_back={sb}"
+                )
+                status, payload = _post(
+                    url=weekly_url,
+                    body=body,
+                    headers=headers,
+                    timeout=args.timeout,
+                )
+                total_calls += 1
+                if 200 <= status < 300:
+                    ok_calls += 1
+                print(f"  -> {_summary(status, payload)}")
+                time.sleep(args.sleep)
+
+    est_cost = total_calls * COST_PER_CALL_USD
+    print()
+    print(f"DONE — {ok_calls}/{total_calls} calls succeeded.")
+    print(f"Estimated cost: ~${est_cost:.2f} ({total_calls} calls * ${COST_PER_CALL_USD:.3f}).")
+    if total_calls - ok_calls:
+        print(
+            f"WARNING: {total_calls - ok_calls} call(s) returned non-2xx — "
+            f"re-run with --force to retry."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_api_admin_ai_review_postdraft_trigger.py
+++ b/tests/test_api_admin_ai_review_postdraft_trigger.py
@@ -124,13 +124,47 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         lambda: state["active_league"],
     )
 
+    # Multi-season chain for backfill tests: LEAGUE_ID (2026) ->
+    # PRIOR123 (2025) -> HIST2024 (2024). Each league has its own
+    # draft_id so the orchestrator can run end-to-end against any
+    # historical season.
+    league_chain: dict[str, dict[str, Any]] = {
+        "LEAGUE_ID": {
+            "league_id": "LEAGUE_ID",
+            "name": "CLT DYNASTY",
+            "draft_id": "DRAFT123",
+            "previous_league_id": "PRIOR123",
+            "season": "2026",
+        },
+        "PRIOR123": {
+            "league_id": "PRIOR123",
+            "name": "CLT DYNASTY (2025)",
+            "draft_id": "DRAFT2025",
+            "previous_league_id": "HIST2024",
+            "season": "2025",
+        },
+        "HIST2024": {
+            "league_id": "HIST2024",
+            "name": "CLT DYNASTY (2024)",
+            "draft_id": "DRAFT2024",
+            "previous_league_id": None,
+            "season": "2024",
+        },
+    }
+    state["league_chain"] = league_chain
+
     def _get_league(league_id: str) -> dict[str, Any]:
-        if league_id == "PRIOR123":
-            return {
-                "league_id": "PRIOR123",
-                "name": "CLT DYNASTY (2025)",
-                "season": "2025",
-            }
+        if league_id in league_chain:
+            entry = dict(league_chain[league_id])
+            # Honor the per-test override on the active league's
+            # previous_league_id so the existing prior-standings test
+            # still works.
+            if league_id == "LEAGUE_ID":
+                entry["previous_league_id"] = state["prior_league_id"]
+            return entry
+        # Default: return a generic league dict so legacy tests still
+        # behave (covers the case where the existing prior_league_id
+        # state hook points elsewhere).
         return {
             "league_id": league_id,
             "name": "CLT DYNASTY",
@@ -140,28 +174,39 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         }
 
     monkeypatch.setattr(orchestrator, "get_sleeper_league", _get_league)
-    monkeypatch.setattr(
-        orchestrator,
-        "get_sleeper_draft",
-        lambda draft_id: {"draft_id": draft_id, "status": state["draft_status"]},
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "get_sleeper_draft_picks",
-        lambda draft_id: _make_picks(),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "get_sleeper_league_users",
-        lambda league_id: _make_sleeper_users(),
-    )
-    monkeypatch.setattr(
-        orchestrator,
-        "get_sleeper_league_rosters",
-        lambda league_id: _make_rosters(),
-    )
+    state["draft_calls"] = []
+    state["picks_calls"] = []
+    state["users_calls"] = []
+    state["rosters_calls"] = []
+
+    def _get_draft(draft_id: str) -> dict[str, Any]:
+        state["draft_calls"].append(draft_id)
+        return {"draft_id": draft_id, "status": state["draft_status"]}
+
+    def _get_picks(draft_id: str) -> list[dict[str, Any]]:
+        state["picks_calls"].append(draft_id)
+        return _make_picks()
+
+    def _get_users(league_id: str) -> list[dict[str, Any]]:
+        state["users_calls"].append(league_id)
+        return _make_sleeper_users()
+
+    def _get_rosters(league_id: str) -> list[dict[str, Any]]:
+        state["rosters_calls"].append(league_id)
+        return _make_rosters()
+
+    monkeypatch.setattr(orchestrator, "get_sleeper_draft", _get_draft)
+    monkeypatch.setattr(orchestrator, "get_sleeper_draft_picks", _get_picks)
+    monkeypatch.setattr(orchestrator, "get_sleeper_league_users", _get_users)
+    monkeypatch.setattr(orchestrator, "get_sleeper_league_rosters", _get_rosters)
 
     def _prior(league_id: str) -> str | None:
+        # Honor the league_chain so historical prior-standings walks
+        # terminate naturally for the 2024 backfill tests.
+        if league_id in league_chain:
+            if league_id == "LEAGUE_ID":
+                return state["prior_league_id"]
+            return league_chain[league_id].get("previous_league_id")
         return state["prior_league_id"]
 
     monkeypatch.setattr(orchestrator, "get_previous_league_id", _prior)
@@ -610,6 +655,172 @@ class TestHandler:
         body = json.loads(response["body"])
         # Sane safe defaults: dry-run on.
         assert body["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Backfill — target_year override
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorTargetYear:
+    """Covers F1 backfill: target_year walks the previous_league_id
+    chain to a specific season and runs the pipeline against THAT
+    league's draft + rosters + users."""
+
+    def test_target_year_2024_walks_chain_to_historical_league(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False, target_year=2024)
+
+        assert result["status"] == "dry_run_sent"
+        assert result["period"] == "2024"
+        assert result["target_year"] == 2024
+        # Draft data fetched against the 2024 draft id.
+        assert "DRAFT2024" in patched_orchestrator["draft_calls"]
+        # Rosters / users fetched against HIST2024.
+        assert "HIST2024" in patched_orchestrator["rosters_calls"]
+        assert "HIST2024" in patched_orchestrator["users_calls"]
+        # Report row persisted with the historical period.
+        write = patched_orchestrator["writes"][0]
+        assert write["period"] == "2024"
+        assert write["metadata"]["target_year"] == 2024
+        assert write["metadata"]["operating_league_id"] == "HIST2024"
+
+    def test_target_year_2025_walks_one_hop(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False, target_year=2025)
+
+        assert result["period"] == "2025"
+        assert "DRAFT2025" in patched_orchestrator["draft_calls"]
+        assert "PRIOR123" in patched_orchestrator["rosters_calls"]
+        write = patched_orchestrator["writes"][0]
+        assert write["period"] == "2025"
+
+    def test_target_year_nonexistent_raises_not_found(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+        from lambdas.common.errors import NotFoundError
+
+        with pytest.raises(NotFoundError):
+            run(dry_run=True, force=False, target_year=9999)
+        # No write happened.
+        assert patched_orchestrator["writes"] == []
+
+    def test_idempotency_per_target_year_period(
+        self, patched_orchestrator
+    ) -> None:
+        """Existing 2024 report should not block a 2025 backfill."""
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": "LEAGUE_ID",
+            "report_type": "postDraft",
+            "period": "2024",
+            "created_at": "2026-05-19T00:00:00Z",
+        }
+        # Different period (2025) — should NOT raise even with
+        # force=False.
+        result = run(dry_run=True, force=False, target_year=2025)
+        assert result["period"] == "2025"
+
+    def test_idempotency_same_target_year_still_409s(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+        from lambdas.common.errors import ReportAlreadyExistsError
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": "LEAGUE_ID",
+            "report_type": "postDraft",
+            "period": "2024",
+            "created_at": "2026-05-19T00:00:00Z",
+        }
+        with pytest.raises(ReportAlreadyExistsError):
+            run(dry_run=True, force=False, target_year=2024)
+
+    def test_default_target_year_none_unchanged(
+        self, patched_orchestrator
+    ) -> None:
+        """Existing behavior (no target_year) still writes period=2026."""
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+        assert result["period"] == "2026"
+        assert result["target_year"] is None
+        write = patched_orchestrator["writes"][0]
+        assert write["period"] == "2026"
+        # Fetches relative to the active league.
+        assert "DRAFT123" in patched_orchestrator["draft_calls"]
+        assert "LEAGUE_ID" in patched_orchestrator["rosters_calls"]
+
+
+class TestHandlerTargetYear:
+    """API handler integration: target_year body param."""
+
+    def test_handler_target_year_2024_returns_200_with_period(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": True, "target_year": 2024}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        import json
+
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["period"] == "2024"
+        assert body["target_year"] == 2024
+
+    def test_handler_target_year_string_coerced(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """API GW sometimes delivers numbers as strings — coerce."""
+        from lambdas.api_admin_ai_review_postdraft_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": True, "target_year": "2025"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        import json
+
+        body = json.loads(response["body"])
+        assert body["period"] == "2025"
+
+    def test_handler_target_year_not_found_returns_404(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": True, "target_year": 9999}),
+            context=None,
+        )
+        assert response["statusCode"] == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_admin_ai_review_weekly_trigger.py
+++ b/tests/test_api_admin_ai_review_weekly_trigger.py
@@ -175,13 +175,39 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         lambda: state["active_league"],
     )
 
+    # Two-hop historical chain for `seasons_back` backfill tests:
+    #   LEAGUE_ID (2026) -> PRIOR_LEAGUE_ID (2025) -> HIST_2024 (2024).
+    league_chain: dict[str, dict[str, Any]] = {
+        LEAGUE_ID: {
+            "league_id": LEAGUE_ID,
+            "name": "CLT DYNASTY",
+            "previous_league_id": PRIOR_LEAGUE_ID,
+            "season": "2026",
+        },
+        PRIOR_LEAGUE_ID: {
+            "league_id": PRIOR_LEAGUE_ID,
+            "name": "CLT DYNASTY (2025)",
+            "previous_league_id": "HIST_2024",
+            "season": "2025",
+        },
+        "HIST_2024": {
+            "league_id": "HIST_2024",
+            "name": "CLT DYNASTY (2024)",
+            "previous_league_id": None,
+            "season": "2024",
+        },
+    }
+    state["league_chain"] = league_chain
+
     def _get_league(league_id: str) -> dict[str, Any]:
-        if league_id == PRIOR_LEAGUE_ID:
-            return {
-                "league_id": PRIOR_LEAGUE_ID,
-                "name": "CLT DYNASTY (2025)",
-                "season": "2025",
-            }
+        if league_id in league_chain:
+            entry = dict(league_chain[league_id])
+            if league_id == LEAGUE_ID:
+                # Honor the per-test override on the active league's
+                # previous_league_id so the existing
+                # `test_no_previous_league_raises` test keeps working.
+                entry["previous_league_id"] = state["prior_league_id"]
+            return entry
         return {
             "league_id": league_id,
             "name": "CLT DYNASTY",
@@ -192,7 +218,10 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(orch, "get_sleeper_league", _get_league)
     monkeypatch.setattr(orch, "get_nfl_state", lambda: state["nfl_state"])
 
+    state["matchup_calls"] = []
+
     def _matchups(league_id: str, week: int) -> list[dict[str, Any]]:
+        state["matchup_calls"].append((league_id, week))
         # Allow tests to override matchups per (league, week).
         key = (league_id, week)
         if key in state["matchups_by_league_week"]:
@@ -947,3 +976,254 @@ class TestHandler:
         assert response["statusCode"] == 200
         body = json.loads(response["body"])
         assert body["use_previous_season"] is True
+
+
+# ---------------------------------------------------------------------------
+# Backfill — seasons_back (replaces use_previous_season)
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorSeasonsBack:
+    """Covers the generic `seasons_back` arg: 0 = current,
+    1 = prior season, 2 = two seasons ago, etc. The deprecated
+    `use_previous_season` alias still maps to 1 for back-compat."""
+
+    def test_seasons_back_zero_is_default_current_season(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=4, dry_run=True, force=False)
+        assert result["seasons_back"] == 0
+        assert result["use_previous_season"] is False
+        # Matchups fetched against the active league.
+        assert patched_orchestrator["matchup_calls"][0][0] == LEAGUE_ID
+        # Period uses the current season.
+        assert result["period"] == "2026W04"
+
+    def test_seasons_back_one_walks_to_prior_league(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(
+            week=4, dry_run=True, force=False, seasons_back=1
+        )
+        assert result["seasons_back"] == 1
+        # Back-compat surface still set.
+        assert result["use_previous_season"] is True
+        # Matchups fetched against the prior league.
+        assert patched_orchestrator["matchup_calls"][0][0] == PRIOR_LEAGUE_ID
+        # Period uses the historical season (2025).
+        assert result["period"] == "2025W04"
+        write = patched_orchestrator["writes"][0]
+        assert write["period"] == "2025W04"
+        assert write["metadata"]["seasons_back"] == 1
+        assert write["metadata"]["matchup_league_id"] == PRIOR_LEAGUE_ID
+
+    def test_seasons_back_two_walks_twice(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(
+            week=4, dry_run=True, force=False, seasons_back=2
+        )
+        assert result["seasons_back"] == 2
+        # Matchups fetched against the two-hop league.
+        assert patched_orchestrator["matchup_calls"][0][0] == "HIST_2024"
+        assert result["period"] == "2024W04"
+        write = patched_orchestrator["writes"][0]
+        assert write["period"] == "2024W04"
+        assert write["metadata"]["matchup_league_id"] == "HIST_2024"
+
+    def test_seasons_back_exceeds_chain_raises(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.errors import NotFoundError
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        # Chain only goes 2 hops deep, request 10.
+        with pytest.raises(NotFoundError):
+            run_weekly(
+                week=4, dry_run=True, force=False, seasons_back=10
+            )
+        # No write happened.
+        assert patched_orchestrator["writes"] == []
+
+    def test_seasons_back_negative_raises_validation(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.errors import ValidationError
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        with pytest.raises(ValidationError):
+            run_weekly(
+                week=4, dry_run=True, force=False, seasons_back=-1
+            )
+
+    def test_use_previous_season_back_compat_maps_to_one(
+        self, patched_orchestrator
+    ) -> None:
+        """Deprecated alias still works — should resolve to
+        seasons_back=1 with the same downstream behavior."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(
+            week=4,
+            dry_run=True,
+            force=False,
+            use_previous_season=True,
+        )
+        assert result["seasons_back"] == 1
+        assert result["use_previous_season"] is True
+        assert patched_orchestrator["matchup_calls"][0][0] == PRIOR_LEAGUE_ID
+        assert result["period"] == "2025W04"
+
+    def test_seasons_back_bypasses_offseason_preflight(
+        self, patched_orchestrator
+    ) -> None:
+        """Backfill against finished seasons works even when current
+        NFL state is offseason — this is the whole point."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "off",
+            "week": 0,
+        }
+        result = run_weekly(
+            week=4, dry_run=True, force=False, seasons_back=2
+        )
+        assert result["status"] == "dry_run_sent"
+        assert result["period"] == "2024W04"
+
+    def test_idempotency_per_historical_period(
+        self, patched_orchestrator
+    ) -> None:
+        """Existing 2024W04 row should not block 2025W04 writes."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": LEAGUE_ID,
+            "report_type": "weekly",
+            "period": "2024W04",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        result = run_weekly(
+            week=4, dry_run=True, force=False, seasons_back=1
+        )
+        assert result["period"] == "2025W04"
+
+    def test_idempotency_same_historical_period_409s(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.errors import ReportAlreadyExistsError
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["existing_report"] = {
+            "league_id": LEAGUE_ID,
+            "report_type": "weekly",
+            "period": "2024W04",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+        with pytest.raises(ReportAlreadyExistsError):
+            run_weekly(
+                week=4, dry_run=True, force=False, seasons_back=2
+            )
+
+
+class TestHandlerSeasonsBack:
+    def test_handler_seasons_back_2_returns_2024_period(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body: {"sleeper_user_id": ADMIN_ID},
+        )
+        response = h.handler(
+            _api_event(
+                body={
+                    "week": 4,
+                    "dry_run": True,
+                    "force": True,
+                    "seasons_back": 2,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["seasons_back"] == 2
+        assert body["period"] == "2024W04"
+
+    def test_handler_seasons_back_string_coerced(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body: {"sleeper_user_id": ADMIN_ID},
+        )
+        response = h.handler(
+            _api_event(
+                body={"week": 4, "dry_run": True, "seasons_back": "1"}
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["seasons_back"] == 1
+        assert body["period"] == "2025W04"
+
+    def test_handler_seasons_back_10_returns_404(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body: {"sleeper_user_id": ADMIN_ID},
+        )
+        response = h.handler(
+            _api_event(
+                body={"week": 4, "dry_run": True, "seasons_back": 10}
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 404
+
+    def test_handler_iOS_payload_unchanged_no_seasons_back(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """iOS only sends {week, dry_run, force} — seasons_back
+        defaults to 0 and the response shape doesn't change."""
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body: {"sleeper_user_id": ADMIN_ID},
+        )
+        response = h.handler(
+            _api_event(body={"week": 4, "dry_run": True, "force": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["seasons_back"] == 0
+        assert body["period"] == "2026W04"

--- a/tests/test_season_resolver.py
+++ b/tests/test_season_resolver.py
@@ -1,0 +1,174 @@
+"""
+Tests for `lambdas.common.season_resolver`.
+
+The resolver walks Sleeper's `previous_league_id` chain backwards
+from an active league. Two modes:
+  - `resolve_historical_league(league_id, seasons_back=N)` — walk
+    exactly N hops.
+  - `resolve_league_by_year(league_id, target_year=Y)` — walk
+    until `season == str(Y)`.
+
+Both helpers accept an injectable `league_fetcher` so tests don't
+need to monkeypatch the underlying HTTP call.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lambdas.common.errors import NotFoundError
+from lambdas.common.season_resolver import (
+    resolve_historical_league,
+    resolve_league_by_year,
+)
+
+
+# Three-season chain shared by every test below:
+#   ACTIVE (2026) -> P1 (2025) -> P2 (2024) -> P3 (2023) -> None.
+CHAIN = {
+    "ACTIVE": {
+        "league_id": "ACTIVE",
+        "season": "2026",
+        "previous_league_id": "P1",
+    },
+    "P1": {
+        "league_id": "P1",
+        "season": "2025",
+        "previous_league_id": "P2",
+    },
+    "P2": {
+        "league_id": "P2",
+        "season": "2024",
+        "previous_league_id": "P3",
+    },
+    "P3": {
+        "league_id": "P3",
+        "season": "2023",
+        "previous_league_id": None,
+    },
+}
+
+
+def _fetch(league_id: str) -> dict:
+    return CHAIN[league_id]
+
+
+class TestResolveHistoricalLeague:
+    def test_zero_returns_active(self) -> None:
+        result = resolve_historical_league(
+            "ACTIVE", 0, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "ACTIVE"
+        assert result["season"] == "2026"
+
+    def test_one_hop(self) -> None:
+        result = resolve_historical_league(
+            "ACTIVE", 1, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P1"
+        assert result["season"] == "2025"
+
+    def test_two_hops(self) -> None:
+        result = resolve_historical_league(
+            "ACTIVE", 2, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P2"
+        assert result["season"] == "2024"
+
+    def test_three_hops_terminal(self) -> None:
+        result = resolve_historical_league(
+            "ACTIVE", 3, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P3"
+
+    def test_too_many_hops_raises(self) -> None:
+        with pytest.raises(NotFoundError):
+            resolve_historical_league(
+                "ACTIVE", 4, league_fetcher=_fetch
+            )
+
+    def test_negative_seasons_back_raises(self) -> None:
+        with pytest.raises(NotFoundError):
+            resolve_historical_league(
+                "ACTIVE", -1, league_fetcher=_fetch
+            )
+
+    def test_empty_string_previous_league_id_terminates(self) -> None:
+        chain = {
+            "A": {
+                "league_id": "A",
+                "season": "2026",
+                "previous_league_id": "",
+            }
+        }
+        with pytest.raises(NotFoundError):
+            resolve_historical_league(
+                "A", 1, league_fetcher=lambda lid: chain[lid]
+            )
+
+    def test_zero_string_previous_league_id_terminates(self) -> None:
+        chain = {
+            "A": {
+                "league_id": "A",
+                "season": "2026",
+                "previous_league_id": "0",
+            }
+        }
+        with pytest.raises(NotFoundError):
+            resolve_historical_league(
+                "A", 1, league_fetcher=lambda lid: chain[lid]
+            )
+
+
+class TestResolveLeagueByYear:
+    def test_target_active_year(self) -> None:
+        result = resolve_league_by_year(
+            "ACTIVE", 2026, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "ACTIVE"
+
+    def test_target_one_back(self) -> None:
+        result = resolve_league_by_year(
+            "ACTIVE", 2025, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P1"
+
+    def test_target_two_back(self) -> None:
+        result = resolve_league_by_year(
+            "ACTIVE", 2024, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P2"
+
+    def test_target_three_back(self) -> None:
+        result = resolve_league_by_year(
+            "ACTIVE", 2023, league_fetcher=_fetch
+        )
+        assert result["league_id"] == "P3"
+
+    def test_target_year_unreachable_raises(self) -> None:
+        with pytest.raises(NotFoundError):
+            resolve_league_by_year(
+                "ACTIVE", 1999, league_fetcher=_fetch
+            )
+
+    def test_target_year_forward_raises(self) -> None:
+        """The chain only walks BACKWARDS — 2027 is unreachable
+        from a 2026 active league."""
+        with pytest.raises(NotFoundError):
+            resolve_league_by_year(
+                "ACTIVE", 2027, league_fetcher=_fetch
+            )
+
+    def test_target_year_as_string_coerce_safe(self) -> None:
+        """The resolver compares str(target_year) — passing 2024
+        works even if Sleeper's season field varies in case."""
+        chain = {
+            "A": {
+                "league_id": "A",
+                "season": "2024",
+                "previous_league_id": None,
+            }
+        }
+        result = resolve_league_by_year(
+            "A", 2024, league_fetcher=lambda lid: chain[lid]
+        )
+        assert result["league_id"] == "A"


### PR DESCRIPTION
## Summary
Extends F1 (post-draft) and F3 (weekly) AI Review lambdas to support backfill against historical seasons so 2024 + 2025 can be seeded into the archive (and the Claude prompts stress-tested against real finished-season data) before the 2026 launch.

References Xomware/xomper-ios#79.

## New params

- **F1 postDraft** — `target_year: int | None = None`. When set, walks `previous_league_id` from the active league until a league with `season == str(target_year)` is found, then runs the entire pipeline (draft picks, rosters, users, prior standings) against THAT league. Period becomes `str(target_year)`. Idempotency keyed by `(active league_id, "postDraft", period)` so 2024 + 2025 + current can all coexist.
- **F3 weekly** — `seasons_back: int = 0` (replaces `use_previous_season: bool`). 0 = current season (existing behavior), 1 = prior season, 2 = two seasons ago, etc. Period becomes `f"{year}W{week:02d}"` on the resolved historical league (e.g. `2024W05`).
- **`use_previous_season`** kept as a DEPRECATED alias mapping to `seasons_back=1` with a runtime warning. F3 plan callers + iOS admin flow keep working as-is.

## Files changed

- `lambdas/common/season_resolver.py` — NEW. Shared walk-the-chain helper (`resolve_historical_league` + `resolve_league_by_year`).
- `lambdas/api_admin_ai_review_postdraft_trigger/handler.py` + `orchestrator.py` — accept `target_year`, compute dynamic `period`, run pipeline against resolved historical league.
- `lambdas/common/weekly_orchestrator.py` — `seasons_back` arg + back-compat alias mapping. All Sleeper fetches relative to the resolved league.
- `lambdas/api_admin_ai_review_weekly_trigger/handler.py` + `lambdas/notif_ai_review_weekly/handler.py` — plumb `seasons_back` through.
- `scripts/backfill_ai_reports.py` — NEW. Manual driver: reads `XOMPER_API_BASE_URL`, `XOMPER_ADMIN_JWT`, `XOMPER_ADMIN_SLEEPER_USER_ID` from env, iterates years × (postDraft + weekly), prints progress + cost estimate. Defaults to `--dry-run` so it can't accidentally broadcast.
- `tests/test_season_resolver.py` (15 new), `tests/test_api_admin_ai_review_postdraft_trigger.py` (+9 new), `tests/test_api_admin_ai_review_weekly_trigger.py` (+13 new).

## Cost estimate

2 years × (1 postDraft + 17 weekly) = ~36 calls × ~\$0.02/call (Haiku 4.5 w/ prompt cache) ≈ **\$0.72** for the full backfill.

## iOS contract — preserved

- iOS postDraft button still sends `{dry_run, force}` → `target_year` defaults to `None` → existing behavior.
- iOS weekly button still sends `{week, dry_run, force}` → `seasons_back` defaults to `0` → existing behavior.
- New params are opt-in.

## Test plan

- [x] All 238 pre-existing tests still pass
- [x] 37 new tests pass (15 resolver + 9 F1 target_year + 13 F3 seasons_back)
- [x] `python3 -m pytest tests/` — 275 passed
- [ ] Smoke-test driver in dry-run mode against a deployed environment before broadcasting (out of scope here)

## Notes

- Script is OPT-IN and manually run — not wired into CI.
- `AI_REVIEW_POSTDRAFT_PERIOD = "2026"` stays in constants as the DEFAULT for non-backfill calls.
- The orchestrators use the deprecation warning only when `use_previous_season` is truthy. The cron + admin handlers both default the alias to `False` so the back-compat path stays quiet for normal traffic.