### PR TITLE
feat(ai-review): add 'mock' to REPORT_TYPES for mock draft surface

### DIFF
--- a/lambdas/common/ai_reports_store.py
+++ b/lambdas/common/ai_reports_store.py
@@ -24,7 +24,7 @@ Schema
     - `metadata` (M): structured metadata
       `{prompt_version, model, token_usage_in, token_usage_out,
         source_data_keys, ...}`.
-    - `report_type` (S): `postDraft` | `preseason` | `weekly`.
+    - `report_type` (S): `postDraft` | `preseason` | `weekly` | `mock`.
     - `period` (S): the same period string used in `sk`.
     - `league_id` (S): convenience copy for read paths.
 
@@ -53,9 +53,11 @@ from lambdas.common.logger import get_logger
 
 log = get_logger(__file__)
 
-# Allowed report types. Keep this tight — F1/F2/F3 add nothing new,
-# they each use exactly one of these.
-REPORT_TYPES: tuple[str, ...] = ("postDraft", "preseason", "weekly")
+# Allowed report types. Keep this tight — F1/F2/F3 each use exactly
+# one of postDraft/preseason/weekly. `mock` is a read-only surface
+# for pre-seeded mock draft reports (iOS Draft tab mock cards); no
+# generator lambda writes this type — backfilled directly via boto3.
+REPORT_TYPES: tuple[str, ...] = ("postDraft", "preseason", "weekly", "mock")
 
 GSI_CREATED_AT = "created-at-index"
 

--- a/tests/test_ai_reports_store.py
+++ b/tests/test_ai_reports_store.py
@@ -116,6 +116,21 @@ class TestWriteReport:
                 body_markdown="",
             )
 
+    def test_writes_mock_type(self, dynamo_table) -> None:
+        """`mock` is read-only in prod (backfilled directly), but the
+        store must accept it so the same validation path used by
+        read endpoints permits the type."""
+        store = dynamo_table
+        item = store.write_report(
+            league_id="L1",
+            report_type="mock",
+            period="2026-bpa",
+            body_markdown="# mock bpa",
+            metadata={"prompt_version": "mock-v1"},
+        )
+        assert item["sk"] == "REPORT#mock#2026-bpa"
+        assert item["report_type"] == "mock"
+
     def test_empty_league_id_raises(self, dynamo_table) -> None:
         store = dynamo_table
         from lambdas.common.errors import ValidationError
@@ -155,6 +170,7 @@ class TestGetLatest:
         _put_report(store, "L1", "weekly", "2026W01")
         _put_report(store, "L1", "preseason", "2026-PRE")
         _put_report(store, "L1", "postDraft", "2026-POSTDRAFT")
+        _put_report(store, "L1", "mock", "2026-bpa")
 
         weekly = store.get_latest("L1", "weekly")
         assert weekly is not None
@@ -163,6 +179,11 @@ class TestGetLatest:
         preseason = store.get_latest("L1", "preseason")
         assert preseason is not None
         assert preseason["report_type"] == "preseason"
+
+        mock = store.get_latest("L1", "mock")
+        assert mock is not None
+        assert mock["report_type"] == "mock"
+        assert mock["period"] == "2026-bpa"
 
     def test_no_report_returns_none(self, dynamo_table) -> None:
         store = dynamo_table


### PR DESCRIPTION
## Summary
- Extend `REPORT_TYPES` in `lambdas/common/ai_reports_store.py` to include `"mock"`.
- Both read endpoints (`GET /ai-reports/latest`, `GET /ai-reports/list`) reference `REPORT_TYPES` from the store module, so this single change unblocks both.
- No new logic, no new writes — `mock` rows were backfilled directly via boto3 in this session.

## Why
iOS now surfaces 3 pre-seeded mock draft reports on the Draft tab (`REPORT#mock#2026-bpa`, `REPORT#mock#2026-team-fit`, `REPORT#mock#2026-wildcard`). The validation guard currently rejects `type=mock` with a 400, breaking the iOS fetch.

## Test plan
- [x] `pytest tests/test_ai_reports_store.py` (15 passed, +1 new write test, modified `test_ignores_other_types` to assert `mock` round-trip via `get_latest`)
- [x] Full suite: `pytest tests/` — 276 passed, 0 failed
- [ ] After merge + deploy: iOS hits `GET /ai-reports/list?type=mock` and `GET /ai-reports/latest?type=mock` and receives 200 with the 3 mock rows