### PR TITLE
chore: bump Actions to Node-24 + widen common-tests glob

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # CONFIGURE: set to your base branch (main or develop)
           ref: master

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -19,7 +19,7 @@ jobs:
       has_lambda_changes: ${{ steps.changes.outputs.has_lambda_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
@@ -81,7 +81,13 @@ jobs:
 
       - name: Run common tests
         run: |
-          pytest tests/test_common.py -v --cov=lambdas/common
+          pytest \
+            tests/test_common.py \
+            tests/test_league_lore.py \
+            tests/test_claude_helper.py \
+            tests/test_ai_reports_store.py \
+            tests/test_season_resolver.py \
+            -v --cov=lambdas/common
 
   test-lambdas:
     needs: detect-changes
@@ -93,10 +99,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
@@ -123,10 +129,10 @@ jobs:
       layer_arn: ${{ steps.deploy-layer.outputs.layer_arn }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
@@ -188,10 +194,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/update-all-layers.yml
+++ b/.github/workflows/update-all-layers.yml
@@ -43,7 +43,7 @@ jobs:
       all_lambdas: ${{ steps.list-lambdas.outputs.all_lambdas }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: List all lambda folders
         id: list-lambdas


### PR DESCRIPTION
## Summary

Bumps SHA-pinned GitHub Actions to Node-24-compatible versions ahead of the Node 20 deprecation deadline (~2026-06-02).

Bundles fix for #93 — widens the `test-common` job to run all common-module test files that were silently skipped under the old `test_common.py`-only glob.

## Changes

- `actions/checkout` v4.2.2 → v6.0.2 (SHA `de0fac2e...`)
- `actions/setup-python` v5.3.0 → v6.2.0 (SHA `a309ff8b...`)
- `deploy-backend.yml` test-common job now runs:
  - `test_common.py`
  - `test_league_lore.py`
  - `test_claude_helper.py`
  - `test_ai_reports_store.py`
  - `test_season_resolver.py`

## Test plan

- CI green
- No Node 20 deprecation annotation
- The F0/F3 common-module tests appear in the CI logs

Closes #93