### PR TITLE
fix(ci): retry lambda code deploys on ResourceConflictException

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -216,10 +216,37 @@ jobs:
           FUNCTION_NAME=$(echo $FUNCTION_NAME | tr '_' '-')
 
           echo "Deploying code for $FUNCTION_NAME"
-          aws lambda update-function-code \
-            --function-name $FUNCTION_NAME \
-            --zip-file fileb://${{ matrix.lambda }}.zip \
-            --region $AWS_REGION
+
+          # Wait for any in-flight infra updates to settle before our code push.
+          # Terraform in xomper-infrastructure may still be creating/updating
+          # this lambda concurrently — pushing code while it's in `Pending`
+          # state hits ResourceConflictException. `function-active` waits up
+          # to 10 minutes for the function to reach Active state. If the
+          # lambda doesn't exist yet (terraform hasn't run), bail loudly so
+          # the human can rerun once terraform finishes.
+          if ! aws lambda wait function-active --function-name $FUNCTION_NAME --region $AWS_REGION 2>/dev/null; then
+            echo "::error::Lambda $FUNCTION_NAME not yet Active — terraform may still be applying. Rerun this job after the terraform workflow completes."
+            exit 1
+          fi
+
+          # Retry the code update on ResourceConflictException up to 3 times
+          # with backoff — covers the narrow window where terraform has
+          # finished a create but the lambda's state-machine is still
+          # propagating to `update-function-code`.
+          for attempt in 1 2 3; do
+            if aws lambda update-function-code \
+              --function-name $FUNCTION_NAME \
+              --zip-file fileb://${{ matrix.lambda }}.zip \
+              --region $AWS_REGION 2>&1 | tee /tmp/upd-$attempt.log; then
+              break
+            fi
+            if ! grep -q "ResourceConflictException" /tmp/upd-$attempt.log; then
+              echo "::error::Lambda code update failed (non-retryable)"
+              exit 1
+            fi
+            echo "ResourceConflictException on attempt $attempt — sleeping $((attempt * 10))s before retry"
+            sleep $((attempt * 10))
+          done
 
           # Wait for function to finish updating before config change
           echo "Waiting for function update to complete..."


### PR DESCRIPTION
## Summary

Fixes the race condition we hit 3x during the ai-review epic deploys: when a single push lands both new infra (creating the lambda) AND new backend code (updating that lambda), the two CI workflows race and `aws lambda update-function-code` fails with `ResourceConflictException: The operation cannot be performed at this time`.

## Fix

1. Wait for the lambda to reach `Active` state via `aws lambda wait function-active` before attempting `update-function-code`. Fails loudly if the lambda does not exist yet — terraform must run first.
2. Retry `update-function-code` on `ResourceConflictException` up to 3 times with linear backoff (10s, 20s, 30s).
3. Treats non-conflict errors as non-retryable and exits.

## Test plan

- [ ] Next co-pushed infra+backend PR completes its backend deploy in one CI cycle without manual rerun
- [ ] If a non-conflict error happens (e.g. function name typo), CI still fails fast

Closes #94