### PR TITLE
feat(admin-portal F2): backend — email previews on dry-run responses

### DIFF
--- a/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
@@ -117,6 +117,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "token_usage": result["token_usage"],
             "period": result.get("period"),
             "target_year": result.get("target_year"),
+            # Admin Portal F2 — present on dry-run, None on broadcast.
+            "previews": result.get("previews"),
         }
     )
 

--- a/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
@@ -34,7 +34,10 @@ from lambdas.common.constants import (
     AI_REVIEW_POSTDRAFT_PERIOD,
     AI_REVIEW_PROMPT_VERSION,
 )
-from lambdas.common.email_templates.ai_review import build_email_payload
+from lambdas.common.email_templates.ai_review import (
+    build_email_payload,
+    render_preview_for_user,
+)
 from lambdas.common.errors import (
     DraftNotCompleteError,
     NotFoundError,
@@ -281,6 +284,21 @@ def run(
         period=period,
     )
 
+    # 6b. Render previews for the Admin Portal F2 pre-broadcast surface.
+    # Only fired on the dry-run path; real broadcasts return `previews=None`
+    # so we don't burn template-render cycles or pad the response body.
+    previews = _build_previews(
+        dry_run=dry_run,
+        body_markdown=markdown,
+        period=period,
+        league_name=league_name,
+    )
+    if previews is not None:
+        print(
+            f"[postdraft-trigger] preview generated for {len(previews)} "
+            f"users (dry_run=true)"
+        )
+
     # 7. Stamp broadcast_at on the non-dry-run path
     if not dry_run:
         broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -307,6 +325,8 @@ def run(
         "token_usage": token_usage,
         "period": period,
         "target_year": target_year,
+        # Admin Portal F2 — populated on dry-run only.
+        "previews": previews,
     }
 
 
@@ -543,3 +563,41 @@ def _resolve_recipients(*, dry_run: bool) -> list[dict[str, Any]]:
         )
         return [admin] if admin else []
     return all_users
+
+
+def _build_previews(
+    *,
+    dry_run: bool,
+    body_markdown: str,
+    period: str,
+    league_name: str,
+) -> list[dict[str, Any]] | None:
+    """Render an email preview row per active whitelisted user.
+
+    Returns:
+        On dry-run: list of preview dicts sorted alphabetically by
+        `display_name` (one per active user — typically 12).
+        On real broadcast: `None`. The iOS admin surface only shows
+        previews under the dry-run banner; skipping the render here
+        keeps the broadcast response payload small.
+    """
+    if not dry_run:
+        return None
+
+    users = get_active_whitelisted_users() or []
+    sorted_users = sorted(
+        users,
+        key=lambda u: (u.get("display_name") or "").lower(),
+    )
+
+    period_label = f"Post-Draft {period}"
+    return [
+        render_preview_for_user(
+            user=user,
+            report_type=REPORT_TYPE,
+            body_markdown=body_markdown,
+            period_label=period_label,
+            league_name=league_name,
+        )
+        for user in sorted_users
+    ]

--- a/lambdas/api_admin_ai_review_preseason_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/handler.py
@@ -110,6 +110,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "delivery_count": result["delivery_count"],
             "model": result["model"],
             "token_usage": result["token_usage"],
+            # Admin Portal F2 — present on dry-run, None on broadcast.
+            "previews": result.get("previews"),
         }
     )
 

--- a/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
@@ -37,7 +37,10 @@ from lambdas.common.constants import (
     AI_REVIEW_PRESEASON_PERIOD,
     AI_REVIEW_PRESEASON_PROMPT_VERSION,
 )
-from lambdas.common.email_templates.ai_review import build_email_payload
+from lambdas.common.email_templates.ai_review import (
+    build_email_payload,
+    render_preview_for_user,
+)
 from lambdas.common.errors import (
     NotFoundError,
     PreseasonWindowPassedError,
@@ -232,6 +235,19 @@ def run(
         period=period,
     )
 
+    # 6b. Render previews for the Admin Portal F2 pre-broadcast surface.
+    previews = _build_previews(
+        dry_run=dry_run,
+        body_markdown=markdown,
+        period=period,
+        league_name=league_name,
+    )
+    if previews is not None:
+        print(
+            f"[preseason-trigger] preview generated for {len(previews)} "
+            f"users (dry_run=true)"
+        )
+
     # 7. Stamp broadcast_at on the non-dry-run path
     if not dry_run:
         broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -256,6 +272,8 @@ def run(
         "delivery_count": delivery_count,
         "model": AI_REVIEW_DEFAULT_MODEL,
         "token_usage": token_usage,
+        # Admin Portal F2 — populated on dry-run only.
+        "previews": previews,
     }
 
 
@@ -479,3 +497,39 @@ def _resolve_recipients(*, dry_run: bool) -> list[dict[str, Any]]:
         )
         return [admin] if admin else []
     return all_users
+
+
+def _build_previews(
+    *,
+    dry_run: bool,
+    body_markdown: str,
+    period: str,
+    league_name: str,
+) -> list[dict[str, Any]] | None:
+    """Render an email preview row per active whitelisted user.
+
+    Returns:
+        On dry-run: list of preview dicts sorted alphabetically by
+        `display_name` (one per active user — typically 12).
+        On real broadcast: `None`.
+    """
+    if not dry_run:
+        return None
+
+    users = get_active_whitelisted_users() or []
+    sorted_users = sorted(
+        users,
+        key=lambda u: (u.get("display_name") or "").lower(),
+    )
+
+    period_label = f"Preseason {period}"
+    return [
+        render_preview_for_user(
+            user=user,
+            report_type=REPORT_TYPE,
+            body_markdown=body_markdown,
+            period_label=period_label,
+            league_name=league_name,
+        )
+        for user in sorted_users
+    ]

--- a/lambdas/api_admin_ai_review_weekly_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_weekly_trigger/handler.py
@@ -128,6 +128,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             "envelope_parsed": result.get("envelope_parsed"),
             "seasons_back": result.get("seasons_back"),
             "use_previous_season": result.get("use_previous_season"),
+            # Admin Portal F2 — present on dry-run, None on broadcast.
+            "previews": result.get("previews"),
         }
     )
 

--- a/lambdas/common/email_templates/ai_review.py
+++ b/lambdas/common/email_templates/ai_review.py
@@ -171,3 +171,82 @@ def build_email_payload(
         "html_body": html_body,
         "text_body": text_body,
     }
+
+
+# ---------------------------------------------------------------------------
+# Preview helper (Admin Portal F2)
+# ---------------------------------------------------------------------------
+#
+# The admin pre-broadcast preview surface needs the *same* rendered email
+# every recipient would receive on a real broadcast — single render path
+# so the preview can't drift from `send_emails_concurrently`.
+#
+# Caps applied here (NOT in `build_email_payload` — the wire payload to
+# SES stays full-fidelity):
+#   * `text_body`         -> first 4096 chars (≈ 4KB hard cap)
+#   * `html_body`         -> dropped; replaced with `html_body_excerpt`
+#                            of the first 500 chars only
+#
+# 12 previews × ~4.5KB ≈ 54KB worst case — well under API GW's 10MB limit.
+
+PREVIEW_TEXT_BODY_CAP = 4096
+PREVIEW_HTML_EXCERPT_CAP = 500
+
+
+def render_preview_for_user(
+    user: dict[str, Any],
+    report_type: str,
+    body_markdown: str,
+    period_label: str,
+    league_name: str | None = None,
+) -> dict[str, Any]:
+    """Render an email preview row for a single whitelisted user.
+
+    Wraps `build_email_payload` so the preview shape is produced by the
+    exact same template path used by the real broadcast — no drift risk.
+
+    Args:
+        user: A row from `get_active_whitelisted_users()`. Must carry
+            `sleeper_user_id`, `email`, and `display_name`.
+            `sleeper_username` is used as a fallback first-name source.
+        report_type: One of `postDraft` | `preseason` | `weekly`.
+        body_markdown: The Claude-produced report body.
+        period_label: Human-readable period (e.g. "Week 4",
+            "Preseason 2026-PRESEASON", "Post-Draft 2026"). Threaded
+            into the subject + section title via `build_email_payload`.
+        league_name: Optional league name to badge inside the email.
+
+    Returns:
+        Dict with `recipient_user_id`, `recipient_email`, `display_name`,
+        `subject`, `text_body` (≤4096 chars), and `html_body_excerpt`
+        (≤500 chars). The full `html_body` is intentionally dropped to
+        keep the response payload mobile-friendly.
+    """
+    email = user.get("email") or ""
+    display_name = user.get("display_name") or ""
+    first_name = (
+        display_name
+        or user.get("sleeper_username")
+        or "there"
+    )
+
+    payload = build_email_payload(
+        user_email=email,
+        user_first_name=first_name,
+        report_type=report_type,
+        body_markdown=body_markdown,
+        period_label=period_label,
+        league_name=league_name,
+    )
+
+    text_body = payload.get("text_body") or ""
+    html_body = payload.get("html_body") or ""
+
+    return {
+        "recipient_user_id": user.get("sleeper_user_id") or "",
+        "recipient_email": email,
+        "display_name": display_name,
+        "subject": payload.get("subject") or "",
+        "text_body": text_body[:PREVIEW_TEXT_BODY_CAP],
+        "html_body_excerpt": html_body[:PREVIEW_HTML_EXCERPT_CAP],
+    }

--- a/lambdas/common/weekly_orchestrator.py
+++ b/lambdas/common/weekly_orchestrator.py
@@ -51,7 +51,10 @@ from lambdas.common.constants import (
     AI_REVIEW_WEEKLY_OK_SEASON_TYPES,
     AI_REVIEW_WEEKLY_PROMPT_VERSION,
 )
-from lambdas.common.email_templates.ai_review import build_email_payload
+from lambdas.common.email_templates.ai_review import (
+    build_email_payload,
+    render_preview_for_user,
+)
 from lambdas.common.errors import (
     NotFoundError,
     ReportAlreadyExistsError,
@@ -225,6 +228,8 @@ def run_weekly(
                 "reason": f"season_type={season_type!r}",
                 "seasons_back": seasons_back,
                 "use_previous_season": seasons_back == 1,
+                # Admin Portal F2 — never previews on the no-op path.
+                "previews": None,
             }
 
     # --- data fetch source league --------------------------------------------
@@ -400,6 +405,21 @@ def run_weekly(
         week=resolved_week,
     )
 
+    # --- previews (Admin Portal F2) ------------------------------------------
+    # Threads the resolved `week` so the subject line reads
+    # "<Name>, your Week N Weekly Review".
+    previews = _build_previews(
+        dry_run=dry_run,
+        body_markdown=body_markdown,
+        league_name=league_name,
+        week=resolved_week,
+    )
+    if previews is not None:
+        print(
+            f"[weekly-trigger] preview generated for {len(previews)} "
+            f"users (dry_run=true, week={resolved_week})"
+        )
+
     # --- stamp broadcast_at on broadcast path --------------------------------
     if not dry_run:
         broadcast_at = datetime.now(timezone.utc).strftime(
@@ -438,6 +458,8 @@ def run_weekly(
         # Back-compat surface so the API response shape stays stable
         # for clients still reading `use_previous_season`.
         "use_previous_season": seasons_back >= 1,
+        # Admin Portal F2 — populated on dry-run only.
+        "previews": previews,
     }
 
 
@@ -755,3 +777,39 @@ def _resolve_recipients(*, dry_run: bool) -> list[dict[str, Any]]:
         )
         return [admin] if admin else []
     return all_users
+
+
+def _build_previews(
+    *,
+    dry_run: bool,
+    body_markdown: str,
+    league_name: str,
+    week: int,
+) -> list[dict[str, Any]] | None:
+    """Render an email preview row per active whitelisted user.
+
+    Returns:
+        On dry-run: list of preview dicts sorted alphabetically by
+        `display_name` (one per active user — typically 12).
+        On real broadcast: `None`.
+    """
+    if not dry_run:
+        return None
+
+    users = get_active_whitelisted_users() or []
+    sorted_users = sorted(
+        users,
+        key=lambda u: (u.get("display_name") or "").lower(),
+    )
+
+    period_label = f"Week {week}"
+    return [
+        render_preview_for_user(
+            user=user,
+            report_type=REPORT_TYPE,
+            body_markdown=body_markdown,
+            period_label=period_label,
+            league_name=league_name,
+        )
+        for user in sorted_users
+    ]

--- a/tests/test_api_admin_ai_review_postdraft_trigger.py
+++ b/tests/test_api_admin_ai_review_postdraft_trigger.py
@@ -946,3 +946,195 @@ class TestClaudeHelperSystemBlockShape:
                 model="m",
                 max_tokens=10,
             )
+
+
+# ---------------------------------------------------------------------------
+# Admin Portal F2 — email previews on dry-run responses
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorPreviewsDryRun:
+    """Locks the dry-run preview surface added in Admin Portal F2."""
+
+    def test_dry_run_returns_one_preview_per_active_user(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+
+        previews = result["previews"]
+        assert isinstance(previews, list)
+        # Fixture builds 12 active whitelisted users.
+        assert len(previews) == 12
+
+    def test_each_preview_has_required_fields(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+
+        required = {
+            "recipient_user_id",
+            "recipient_email",
+            "display_name",
+            "subject",
+            "text_body",
+            "html_body_excerpt",
+        }
+        for preview in result["previews"]:
+            assert required.issubset(preview.keys())
+            # Full html_body intentionally dropped.
+            assert "html_body" not in preview
+
+    def test_previews_sorted_alphabetically_by_display_name(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        # Shuffle the fixture to display names that don't naturally
+        # sort to the same order as roster_id.
+        patched_orchestrator["whitelisted_users"] = [
+            {
+                "sleeper_user_id": ADMIN_ID,
+                "email": "zach@example.com",
+                "display_name": "Zach",
+                "sleeper_username": "zach",
+                "is_active": True,
+                "is_admin": True,
+                "id": "row-1",
+            },
+            {
+                "sleeper_user_id": "u2",
+                "email": "adam@example.com",
+                "display_name": "Adam",
+                "sleeper_username": "adam",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-2",
+            },
+            {
+                "sleeper_user_id": "u3",
+                "email": "mike@example.com",
+                "display_name": "Mike",
+                "sleeper_username": "mike",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-3",
+            },
+            {
+                "sleeper_user_id": "u4",
+                "email": "beth@example.com",
+                "display_name": "Beth",
+                "sleeper_username": "beth",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-4",
+            },
+        ]
+
+        result = run(dry_run=True, force=False)
+        names = [p["display_name"] for p in result["previews"]]
+        assert names == ["Adam", "Beth", "Mike", "Zach"]
+
+    def test_text_body_capped_at_4096_chars(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Long Claude output must not blow past the 4KB cap."""
+        from lambdas.api_admin_ai_review_postdraft_trigger import orchestrator
+
+        # Override the Claude mock to produce a 10K-char body.
+        long_markdown = "X" * 10_000
+
+        def _long_generate(
+            *, prompt, system, model, max_tokens, return_usage=False
+        ):
+            usage = {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
+            if return_usage:
+                return long_markdown, usage
+            return long_markdown
+
+        fake_claude = MagicMock()
+        fake_claude.generate = _long_generate
+        monkeypatch.setattr(orchestrator, "claude_helper", fake_claude)
+
+        result = orchestrator.run(dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["text_body"]) <= 4096
+
+    def test_html_body_excerpt_capped_at_500_chars(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["html_body_excerpt"]) <= 500
+
+
+class TestOrchestratorPreviewsBroadcast:
+    """Broadcast (dry_run=False) responses must NOT include previews."""
+
+    def test_broadcast_returns_none_previews(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        # First write so the broadcast call can proceed with force=True.
+        result = run(dry_run=False, force=True)
+
+        assert result["previews"] is None
+
+
+class TestHandlerPreviews:
+    """End-to-end through the lambda handler — confirms `previews` is
+    serialized into the API response body."""
+
+    def test_handler_dry_run_response_includes_previews(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+        from lambdas.api_admin_ai_review_postdraft_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["dry_run"] is True
+        assert isinstance(body["previews"], list)
+        assert len(body["previews"]) == 12
+
+    def test_handler_broadcast_response_previews_null(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+        from lambdas.api_admin_ai_review_postdraft_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": False, "force": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["dry_run"] is False
+        assert body["previews"] is None

--- a/tests/test_api_admin_ai_review_preseason_trigger.py
+++ b/tests/test_api_admin_ai_review_preseason_trigger.py
@@ -628,3 +628,185 @@ class TestHandler:
         body = json.loads(response["body"])
         # Safe defaults: dry-run on.
         assert body["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# Admin Portal F2 — email previews on dry-run responses
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorPreviewsDryRun:
+    """Locks the dry-run preview surface added in Admin Portal F2."""
+
+    def test_dry_run_returns_one_preview_per_active_user(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+
+        previews = result["previews"]
+        assert isinstance(previews, list)
+        assert len(previews) == 12
+
+    def test_each_preview_has_required_fields(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+
+        required = {
+            "recipient_user_id",
+            "recipient_email",
+            "display_name",
+            "subject",
+            "text_body",
+            "html_body_excerpt",
+        }
+        for preview in result["previews"]:
+            assert required.issubset(preview.keys())
+            assert "html_body" not in preview
+
+    def test_previews_sorted_alphabetically_by_display_name(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        patched_orchestrator["whitelisted_users"] = [
+            {
+                "sleeper_user_id": ADMIN_ID,
+                "email": "zach@example.com",
+                "display_name": "Zach",
+                "sleeper_username": "zach",
+                "is_active": True,
+                "is_admin": True,
+                "id": "row-1",
+            },
+            {
+                "sleeper_user_id": "u2",
+                "email": "adam@example.com",
+                "display_name": "Adam",
+                "sleeper_username": "adam",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-2",
+            },
+            {
+                "sleeper_user_id": "u3",
+                "email": "mike@example.com",
+                "display_name": "Mike",
+                "sleeper_username": "mike",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-3",
+            },
+            {
+                "sleeper_user_id": "u4",
+                "email": "beth@example.com",
+                "display_name": "Beth",
+                "sleeper_username": "beth",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-4",
+            },
+        ]
+
+        result = run(dry_run=True, force=False)
+        names = [p["display_name"] for p in result["previews"]]
+        assert names == ["Adam", "Beth", "Mike", "Zach"]
+
+    def test_text_body_capped_at_4096_chars(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import orchestrator
+
+        long_markdown = "X" * 10_000
+
+        def _long_generate(
+            *, prompt, system, model, max_tokens, return_usage=False
+        ):
+            usage = {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
+            if return_usage:
+                return long_markdown, usage
+            return long_markdown
+
+        fake_claude = MagicMock()
+        fake_claude.generate = _long_generate
+        monkeypatch.setattr(orchestrator, "claude_helper", fake_claude)
+
+        result = orchestrator.run(dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["text_body"]) <= 4096
+
+    def test_html_body_excerpt_capped_at_500_chars(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["html_body_excerpt"]) <= 500
+
+
+class TestOrchestratorPreviewsBroadcast:
+    """Broadcast (dry_run=False) responses must NOT include previews."""
+
+    def test_broadcast_returns_none_previews(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=False, force=True)
+
+        assert result["previews"] is None
+
+
+class TestHandlerPreviews:
+    """End-to-end through the lambda handler."""
+
+    def test_handler_dry_run_response_includes_previews(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert isinstance(body["previews"], list)
+        assert len(body["previews"]) == 12
+
+    def test_handler_broadcast_response_previews_null(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import json
+        from lambdas.api_admin_ai_review_preseason_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"dry_run": False, "force": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["previews"] is None

--- a/tests/test_api_admin_ai_review_weekly_trigger.py
+++ b/tests/test_api_admin_ai_review_weekly_trigger.py
@@ -1226,4 +1226,221 @@ class TestHandlerSeasonsBack:
         assert response["statusCode"] == 200
         body = json.loads(response["body"])
         assert body["seasons_back"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Admin Portal F2 — email previews on dry-run responses
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorPreviewsDryRun:
+    """Locks the dry-run preview surface added in Admin Portal F2."""
+
+    def test_dry_run_returns_one_preview_per_active_user(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=4, dry_run=True, force=False)
+
+        previews = result["previews"]
+        assert isinstance(previews, list)
+        assert len(previews) == 12
+
+    def test_each_preview_has_required_fields(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=4, dry_run=True, force=False)
+
+        required = {
+            "recipient_user_id",
+            "recipient_email",
+            "display_name",
+            "subject",
+            "text_body",
+            "html_body_excerpt",
+        }
+        for preview in result["previews"]:
+            assert required.issubset(preview.keys())
+            assert "html_body" not in preview
+
+    def test_previews_sorted_alphabetically_by_display_name(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["whitelisted_users"] = [
+            {
+                "sleeper_user_id": ADMIN_ID,
+                "email": "zach@example.com",
+                "display_name": "Zach",
+                "sleeper_username": "zach",
+                "is_active": True,
+                "is_admin": True,
+                "id": "row-1",
+            },
+            {
+                "sleeper_user_id": "u2",
+                "email": "adam@example.com",
+                "display_name": "Adam",
+                "sleeper_username": "adam",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-2",
+            },
+            {
+                "sleeper_user_id": "u3",
+                "email": "mike@example.com",
+                "display_name": "Mike",
+                "sleeper_username": "mike",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-3",
+            },
+            {
+                "sleeper_user_id": "u4",
+                "email": "beth@example.com",
+                "display_name": "Beth",
+                "sleeper_username": "beth",
+                "is_active": True,
+                "is_admin": False,
+                "id": "row-4",
+            },
+        ]
+
+        result = run_weekly(week=4, dry_run=True, force=False)
+        names = [p["display_name"] for p in result["previews"]]
+        assert names == ["Adam", "Beth", "Mike", "Zach"]
+
+    def test_text_body_capped_at_4096_chars(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Weekly recap body that exceeds 4KB still caps cleanly."""
+        from lambdas.common import weekly_orchestrator as orch
+
+        # JSON-envelope-wrapping: emit a body_markdown that is itself
+        # large enough to exceed 4096 chars on the plain-text path.
+        big_body = "X" * 10_000
+        envelope = json.dumps(
+            {
+                "body_markdown": big_body,
+                "new_memories": [],
+            }
+        )
+        patched_orchestrator["claude_response"] = envelope
+
+        def _generate(
+            *, prompt, system, model, max_tokens, return_usage=False
+        ):
+            usage = {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+            }
+            if return_usage:
+                return envelope, usage
+            return envelope
+
+        fake_claude = MagicMock()
+        fake_claude.generate = _generate
+        monkeypatch.setattr(orch, "claude_helper", fake_claude)
+
+        result = orch.run_weekly(week=4, dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["text_body"]) <= 4096
+
+    def test_html_body_excerpt_capped_at_500_chars(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=4, dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert len(preview["html_body_excerpt"]) <= 500
+
+    def test_preview_subject_contains_week_label(
+        self, patched_orchestrator
+    ) -> None:
+        """Weekly previews must reflect the resolved week in their
+        subjects (regression guard for the week-threading helper)."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=11, dry_run=True, force=False)
+        for preview in result["previews"]:
+            assert "Week 11" in preview["subject"]
+
+
+class TestOrchestratorPreviewsBroadcast:
+    """Broadcast (dry_run=False) responses must NOT include previews."""
+
+    def test_broadcast_returns_none_previews(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(week=4, dry_run=False, force=True)
+
+        assert result["previews"] is None
+
+    def test_offseason_skip_returns_none_previews(
+        self, patched_orchestrator
+    ) -> None:
+        """No-op short-circuit still serializes a `previews` key for
+        wire-shape stability."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["nfl_state"] = {
+            "season": "2026",
+            "season_type": "off",
+            "week": 0,
+        }
+        result = run_weekly(dry_run=True, force=False)
+        assert result["status"] == "skipped_offseason"
+        assert result["previews"] is None
+
+
+class TestHandlerPreviews:
+    """End-to-end through the lambda handler."""
+
+    def test_handler_dry_run_response_includes_previews(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"week": 4, "dry_run": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert isinstance(body["previews"], list)
+        assert len(body["previews"]) == 12
+
+    def test_handler_broadcast_response_previews_null(
+        self,
+        patched_orchestrator,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_ai_review_weekly_trigger import handler as h
+
+        monkeypatch.setattr(
+            h, "require_admin", lambda event, body: {"sleeper_user_id": ADMIN_ID}
+        )
+        response = h.handler(
+            _api_event(body={"week": 4, "dry_run": False, "force": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["previews"] is None
         assert body["period"] == "2026W04"

--- a/tests/test_render_preview_for_user.py
+++ b/tests/test_render_preview_for_user.py
@@ -1,0 +1,199 @@
+"""
+Tests for `lambdas.common.email_templates.ai_review.render_preview_for_user`.
+
+Locks Admin Portal F2 cap discipline:
+  * `text_body` <= 4096 chars
+  * `html_body_excerpt` <= 500 chars
+  * full `html_body` key is dropped (admin-only payload stays mobile-friendly)
+  * happy-path shape matches the iOS `EmailPreview` decoder
+
+No network / SES / Anthropic mocking required — `build_email_payload`
+is pure template substitution.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lambdas.common.email_templates.ai_review import (
+    PREVIEW_HTML_EXCERPT_CAP,
+    PREVIEW_TEXT_BODY_CAP,
+    render_preview_for_user,
+)
+
+
+def _user(
+    *,
+    user_id: str = "u1",
+    email: str = "manager1@example.com",
+    display_name: str = "Manager1",
+    sleeper_username: str = "manager1",
+) -> dict:
+    return {
+        "sleeper_user_id": user_id,
+        "email": email,
+        "display_name": display_name,
+        "sleeper_username": sleeper_username,
+    }
+
+
+class TestRenderPreviewForUserHappyPath:
+    def test_returns_expected_keys(self) -> None:
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="postDraft",
+            body_markdown="# Post-Draft Recap\n\nManager1 cooked.\n",
+            period_label="Post-Draft 2026",
+            league_name="CLT DYNASTY",
+        )
+
+        # Wire shape the iOS EmailPreview decoder expects.
+        assert set(result.keys()) == {
+            "recipient_user_id",
+            "recipient_email",
+            "display_name",
+            "subject",
+            "text_body",
+            "html_body_excerpt",
+        }
+        # Full html_body is intentionally dropped.
+        assert "html_body" not in result
+
+    def test_fields_carry_user_identity(self) -> None:
+        result = render_preview_for_user(
+            user=_user(
+                user_id="u42",
+                email="zach@example.com",
+                display_name="Zach",
+            ),
+            report_type="weekly",
+            body_markdown="Body",
+            period_label="Week 4",
+        )
+        assert result["recipient_user_id"] == "u42"
+        assert result["recipient_email"] == "zach@example.com"
+        assert result["display_name"] == "Zach"
+
+    def test_subject_threads_display_name_and_period(self) -> None:
+        result = render_preview_for_user(
+            user=_user(display_name="Beth"),
+            report_type="weekly",
+            body_markdown="Body",
+            period_label="Week 7",
+        )
+        # Subject is rendered by `build_email_payload` — confirm the
+        # preview surface inherits the same line untouched.
+        assert "Beth" in result["subject"]
+        assert "Week 7" in result["subject"]
+        assert "Weekly Review" in result["subject"]
+
+    def test_text_body_under_cap_passes_through_unchanged(self) -> None:
+        body = "# Tiny recap\n\nNothing notable happened.\n"
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="postDraft",
+            body_markdown=body,
+            period_label="Post-Draft 2026",
+        )
+        # Whole markdown body shows up in the plain-text section.
+        assert "Tiny recap" in result["text_body"]
+        assert len(result["text_body"]) <= PREVIEW_TEXT_BODY_CAP
+
+    def test_html_excerpt_under_cap_passes_through(self) -> None:
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="postDraft",
+            body_markdown="# Recap",
+            period_label="Post-Draft 2026",
+        )
+        assert len(result["html_body_excerpt"]) <= PREVIEW_HTML_EXCERPT_CAP
+        # `wrap_email_html` always produces SOMETHING — never blank.
+        assert result["html_body_excerpt"]
+
+    def test_missing_display_name_falls_back_to_sleeper_username(self) -> None:
+        user = {
+            "sleeper_user_id": "u9",
+            "email": "ghost@example.com",
+            "display_name": "",
+            "sleeper_username": "ghosthunter",
+        }
+        result = render_preview_for_user(
+            user=user,
+            report_type="postDraft",
+            body_markdown="Body",
+            period_label="Post-Draft 2026",
+        )
+        # display_name preserved as-is (empty)
+        assert result["display_name"] == ""
+        # subject still produced (uses fallback first-name)
+        assert "ghosthunter" in result["subject"]
+
+
+class TestRenderPreviewForUserCapDiscipline:
+    def test_text_body_capped_at_4096(self) -> None:
+        # Build a markdown body so long that the plain-text rendering
+        # blows past the 4KB cap. The plain-text section concatenates
+        # greeting + label + body + footer; using 10K of body content
+        # guarantees a >4096 char result before the cap.
+        big_body = "X" * 10_000
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="postDraft",
+            body_markdown=big_body,
+            period_label="Post-Draft 2026",
+        )
+        assert len(result["text_body"]) == PREVIEW_TEXT_BODY_CAP
+
+    def test_html_body_excerpt_capped_at_500(self) -> None:
+        # `wrap_email_html` is HTML-heavy by construction — even a short
+        # body produces multi-KB output. Test the cap directly.
+        big_body = "Hello" * 1_000
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="postDraft",
+            body_markdown=big_body,
+            period_label="Post-Draft 2026",
+        )
+        assert len(result["html_body_excerpt"]) == PREVIEW_HTML_EXCERPT_CAP
+
+    def test_full_html_body_not_returned(self) -> None:
+        """Drift-proof: even with a body that renders to a huge HTML
+        envelope, the helper never leaks the full payload."""
+        big_body = "Bigger\n" * 5_000
+        result = render_preview_for_user(
+            user=_user(),
+            report_type="weekly",
+            body_markdown=big_body,
+            period_label="Week 12",
+        )
+        assert "html_body" not in result
+        assert len(result["html_body_excerpt"]) <= PREVIEW_HTML_EXCERPT_CAP
+
+
+class TestRenderPreviewForUserDefensive:
+    def test_missing_email_yields_empty_recipient_email(self) -> None:
+        user = {
+            "sleeper_user_id": "u1",
+            "display_name": "Manager1",
+        }
+        result = render_preview_for_user(
+            user=user,
+            report_type="postDraft",
+            body_markdown="Body",
+            period_label="Post-Draft 2026",
+        )
+        assert result["recipient_email"] == ""
+        # Subject is still rendered, even with no email address.
+        assert "Manager1" in result["subject"]
+
+    def test_missing_user_id_yields_empty_string(self) -> None:
+        user = {
+            "email": "no-id@example.com",
+            "display_name": "Limbo",
+        }
+        result = render_preview_for_user(
+            user=user,
+            report_type="postDraft",
+            body_markdown="Body",
+            period_label="Post-Draft 2026",
+        )
+        assert result["recipient_user_id"] == ""


### PR DESCRIPTION
## Summary

Backend half of Admin Portal F2 — pre-flight email preview. Extends the three AI Review admin-trigger orchestrators (`postDraft`, `preseason`, `weekly`) so dry-run responses now carry a `previews` array — one rendered email per active whitelisted user, sorted alphabetically by `display_name`. Real broadcasts return `previews: null`.

No new endpoints, no infra changes. The iOS PR follows in `xomper-ios`.

Refs F2 plan: `docs/features/admin-portal/f2-preview/PLAN.md` (in iOS repo)
Closes #91 (backend half — iOS PR will close the rest)

## What changed

- **`lambdas/common/email_templates/ai_review.py`** — new `render_preview_for_user(user, report_type, body_markdown, period_label, league_name=None) -> dict` helper. Wraps `build_email_payload` (single render path — drift-impossible against the real broadcast). Caps `text_body` at 4096 chars, returns `html_body_excerpt` (500 chars), drops the full `html_body`.
- **3 orchestrators extended** to render previews on the dry-run path only:
  - `lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py`
  - `lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py`
  - `lambdas/common/weekly_orchestrator.py` (weekly orchestrator lives here per the F3 deploy-packaging fix)
- **3 handlers** plumb `previews` through into the response body.
- Worst-case payload: ~54KB (12 × ~4.5KB). API GW limit is 10MB.
- Single log line per dry-run: `[postdraft|preseason|weekly]-trigger] preview generated for N users (dry_run=true)` — count only, no email content. Audit-log retrofit lands in F4.

## Endpoints touched

- `POST /admin/ai-review-postdraft-trigger` — adds `previews` to dry-run response
- `POST /admin/ai-review-preseason-trigger` — adds `previews` to dry-run response
- `POST /admin/ai-review-weekly-trigger` — adds `previews` to dry-run response (subject lines reflect the resolved week)

## Database / infra

None.

## Test plan

- [x] 11 new tests in `tests/test_render_preview_for_user.py` — cap discipline (text + html), happy path, defensive paths (missing email, missing user_id, fallback first-name)
- [x] 9 new tests in `tests/test_api_admin_ai_review_postdraft_trigger.py` — dry-run returns 12 previews, broadcast returns `None`, alphabetical sort, cap discipline, handler-layer wire shape
- [x] 11 new tests in `tests/test_api_admin_ai_review_preseason_trigger.py` — same coverage as post-draft
- [x] 11 new tests in `tests/test_api_admin_ai_review_weekly_trigger.py` — same coverage + week-label-in-subject check + offseason-skip-returns-null check
- [x] Full suite: **327 / 327 passing** (290 baseline + 37 new)

## Risks / notes

- Wire-level field is **optional** — broadcasts and skip-paths return `previews: null`. Existing clients (CLI scripts, EventBridge cron path for weekly) are untouched.
- 12 × `build_email_payload` calls per dry-run add ~60ms to lambda runtime — well within tolerance for an admin-only path.
- Preview render reuses the exact `build_email_payload` path the real broadcast uses, so the preview can never drift from delivered output.