### PR TITLE
feat(admin-portal F3): backend — redact + do-not-broadcast + broadcast_at

### DIFF
--- a/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/handler.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from lambdas.common.admin_gate import NotAdmin, require_admin
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     DraftNotCompleteError,
     ReportAlreadyExistsError,
     XomperError,
@@ -99,6 +100,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "draft_status": err.details.get("draft_status"),
             },
             status_code=412,
+        )
+    except DoNotBroadcastError as err:
+        err.log_error()
+        return success_response(
+            {
+                "Success": False,
+                "error": "do_not_broadcast",
+                "Message": err.message,
+            },
+            status_code=409,
         )
     except XomperError as err:
         # ClaudeAPIError / SleeperAPIError / DynamoDBError /

--- a/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/orchestrator.py
@@ -23,7 +23,6 @@ Returns a dict suitable for JSON-encoding in the API response.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
 
 from lambdas.common import ai_reports_store, claude_helper
@@ -39,6 +38,7 @@ from lambdas.common.email_templates.ai_review import (
     render_preview_for_user,
 )
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     DraftNotCompleteError,
     NotFoundError,
     ReportAlreadyExistsError,
@@ -275,7 +275,15 @@ def run(
         metadata=metadata,
     )
 
-    # 6. Deliver
+    # 6. Pre-broadcast DNB check (Admin Portal F3).
+    # Re-read the row right before SES fan-out so admins who flipped
+    # `do_not_broadcast=true` AFTER generation but BEFORE broadcast
+    # still get the abort. Dry-run path skips — locking only matters
+    # for real-broadcast attempts.
+    if not dry_run:
+        _enforce_not_dnb(league_id=league_id, period=period)
+
+    # 7. Deliver
     delivery_count = _deliver(
         dry_run=dry_run,
         league_id=league_id,
@@ -284,7 +292,7 @@ def run(
         period=period,
     )
 
-    # 6b. Render previews for the Admin Portal F2 pre-broadcast surface.
+    # 7b. Render previews for the Admin Portal F2 pre-broadcast surface.
     # Only fired on the dry-run path; real broadcasts return `previews=None`
     # so we don't burn template-render cycles or pad the response body.
     previews = _build_previews(
@@ -299,20 +307,21 @@ def run(
             f"users (dry_run=true)"
         )
 
-    # 7. Stamp broadcast_at on the non-dry-run path
+    # 8. Stamp broadcast_at on the non-dry-run path AFTER SES success.
+    # Partial-failure safe: helper only runs if `_deliver` returned
+    # without raising.
     if not dry_run:
-        broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         try:
-            ai_reports_store.update_metadata(
+            updated = ai_reports_store.stamp_broadcast_at(
                 league_id=league_id,
                 report_type=REPORT_TYPE,
                 period=period,
-                partial={"broadcast_at": broadcast_at},
             )
-            metadata["broadcast_at"] = broadcast_at
-            report_row["metadata"] = metadata
+            if isinstance(updated, dict) and updated.get("metadata"):
+                metadata.update(updated["metadata"])
+                report_row["metadata"] = metadata
         except Exception as err:  # noqa: BLE001 — non-blocking
-            log.warning(f"update_metadata broadcast_at failed: {err}")
+            log.warning(f"stamp_broadcast_at failed: {err}")
 
     status = "dry_run_sent" if dry_run else "broadcast"
     return {
@@ -333,6 +342,35 @@ def run(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _enforce_not_dnb(*, league_id: str, period: str) -> None:
+    """Re-read the just-written report row and raise
+    `DoNotBroadcastError` (HTTP 409) when `metadata.do_not_broadcast`
+    is truthy. Called immediately before SES fan-out on the real-
+    broadcast path only — dry-run delivery is unaffected.
+
+    Cheap: one Dynamo `get_item`. Catches the race where an admin
+    flips DNB on between `write_report` and the broadcast attempt.
+    """
+    fresh = ai_reports_store.get_report(
+        league_id=league_id,
+        report_type=REPORT_TYPE,
+        period=period,
+    )
+    if not fresh:
+        return
+    meta = fresh.get("metadata") or {}
+    flag = meta.get("do_not_broadcast")
+    # Persists as "true"/"false" string (admin-portal F3 flag endpoint
+    # writes through `update_metadata` with stringified bools) but
+    # accept native bool too for forward-compat.
+    if flag is True or (isinstance(flag, str) and flag.lower() == "true"):
+        raise DoNotBroadcastError(
+            handler="notif_ai_review_postdraft",
+            report_type=REPORT_TYPE,
+            period=period,
+        )
 
 
 def _build_prior_standings(

--- a/lambdas/api_admin_ai_review_preseason_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/handler.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from lambdas.common.admin_gate import NotAdmin, require_admin
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     PreseasonWindowPassedError,
     ReportAlreadyExistsError,
     XomperError,
@@ -94,6 +95,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "season_type": err.details.get("season_type"),
             },
             status_code=412,
+        )
+    except DoNotBroadcastError as err:
+        err.log_error()
+        return success_response(
+            {
+                "Success": False,
+                "error": "do_not_broadcast",
+                "Message": err.message,
+            },
+            status_code=409,
         )
     except XomperError as err:
         # ClaudeAPIError / SleeperAPIError / DynamoDBError /

--- a/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
+++ b/lambdas/api_admin_ai_review_preseason_trigger/orchestrator.py
@@ -25,7 +25,6 @@ Returns a dict suitable for JSON-encoding in the API response.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
 
 from lambdas.common import ai_reports_store, claude_helper
@@ -42,6 +41,7 @@ from lambdas.common.email_templates.ai_review import (
     render_preview_for_user,
 )
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     NotFoundError,
     PreseasonWindowPassedError,
     ReportAlreadyExistsError,
@@ -226,7 +226,15 @@ def run(
         metadata=metadata,
     )
 
-    # 6. Deliver
+    # 6. Pre-broadcast DNB check (Admin Portal F3).
+    # Re-read the row right before SES fan-out so admins who flipped
+    # `do_not_broadcast=true` AFTER generation but BEFORE broadcast
+    # still get the abort. Dry-run path skips — locking only matters
+    # for real-broadcast attempts.
+    if not dry_run:
+        _enforce_not_dnb(league_id=league_id, period=period)
+
+    # 7. Deliver
     delivery_count = _deliver(
         dry_run=dry_run,
         league_id=league_id,
@@ -235,7 +243,7 @@ def run(
         period=period,
     )
 
-    # 6b. Render previews for the Admin Portal F2 pre-broadcast surface.
+    # 7b. Render previews for the Admin Portal F2 pre-broadcast surface.
     previews = _build_previews(
         dry_run=dry_run,
         body_markdown=markdown,
@@ -248,20 +256,19 @@ def run(
             f"users (dry_run=true)"
         )
 
-    # 7. Stamp broadcast_at on the non-dry-run path
+    # 8. Stamp broadcast_at on the non-dry-run path AFTER SES success.
     if not dry_run:
-        broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         try:
-            ai_reports_store.update_metadata(
+            updated = ai_reports_store.stamp_broadcast_at(
                 league_id=league_id,
                 report_type=REPORT_TYPE,
                 period=period,
-                partial={"broadcast_at": broadcast_at},
             )
-            metadata["broadcast_at"] = broadcast_at
-            report_row["metadata"] = metadata
+            if isinstance(updated, dict) and updated.get("metadata"):
+                metadata.update(updated["metadata"])
+                report_row["metadata"] = metadata
         except Exception as err:  # noqa: BLE001 — non-blocking
-            log.warning(f"update_metadata broadcast_at failed: {err}")
+            log.warning(f"stamp_broadcast_at failed: {err}")
 
     status = "dry_run_sent" if dry_run else "broadcast"
     return {
@@ -280,6 +287,32 @@ def run(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _enforce_not_dnb(*, league_id: str, period: str) -> None:
+    """Re-read the just-written report row and raise
+    `DoNotBroadcastError` (HTTP 409) when `metadata.do_not_broadcast`
+    is truthy. Called immediately before SES fan-out on the real-
+    broadcast path only — dry-run delivery is unaffected.
+
+    Cheap: one Dynamo `get_item`. Catches the race where an admin
+    flips DNB on between `write_report` and the broadcast attempt.
+    """
+    fresh = ai_reports_store.get_report(
+        league_id=league_id,
+        report_type=REPORT_TYPE,
+        period=period,
+    )
+    if not fresh:
+        return
+    meta = fresh.get("metadata") or {}
+    flag = meta.get("do_not_broadcast")
+    if flag is True or (isinstance(flag, str) and flag.lower() == "true"):
+        raise DoNotBroadcastError(
+            handler="notif_ai_review_preseason",
+            report_type=REPORT_TYPE,
+            period=period,
+        )
 
 
 def _build_prior_standings(

--- a/lambdas/api_admin_ai_review_weekly_trigger/handler.py
+++ b/lambdas/api_admin_ai_review_weekly_trigger/handler.py
@@ -47,6 +47,7 @@ from typing import Any
 
 from lambdas.common.admin_gate import NotAdmin, require_admin
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     ReportAlreadyExistsError,
     XomperError,
     handle_errors,
@@ -102,6 +103,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 "error": "already_generated",
                 "Message": err.message,
                 "existing": err.details.get("existing"),
+            },
+            status_code=409,
+        )
+    except DoNotBroadcastError as err:
+        err.log_error()
+        return success_response(
+            {
+                "Success": False,
+                "error": "do_not_broadcast",
+                "Message": err.message,
             },
             status_code=409,
         )

--- a/lambdas/api_admin_reports_flag/handler.py
+++ b/lambdas/api_admin_reports_flag/handler.py
@@ -1,0 +1,187 @@
+"""
+POST /admin/reports-flag
+========================
+Admin-only endpoint that toggles one of the broadcast-safety flags
+on an AI Review report row.
+
+NOTE on the path: the infra module flattens nested REST routes to a
+single `path_part` segment under `/admin`, so what the plan refers
+to as `/admin/reports/{league_id}/{report_type}/{period}/flag` is
+deployed at `/admin/reports-flag` (infra PR #109). Same admin gate,
+identifiers live in the body.
+
+Body:
+{
+    "sleeper_user_id": "abc123",          // required — admin gate identity
+    "email":           "user@example.com", // optional fallback identity
+    "league_id":       "LEAGUE_ID",        // required — Sleeper league id
+    "report_type":     "weekly",           // required — postDraft | preseason | weekly | mock
+    "period":          "2026W04",          // required — period string
+    "flag":            "is_redacted",      // required — "is_redacted" | "do_not_broadcast"
+    "value":           true                // required — bool
+}
+
+Behavior:
+- 200 + Success=true on a happy-path toggle. Response carries the
+  FULL updated metadata dict so iOS can refresh local state in place.
+- 400 on bad input (missing field, invalid flag name, non-bool value).
+- 403 when the caller is not an admin.
+- 404 when the targeted report doesn't exist.
+- 500 on Dynamo / unexpected failures.
+
+Response:
+{
+    "Success":     true,
+    "league_id":   "LEAGUE_ID",
+    "report_type": "weekly",
+    "period":      "2026W04",
+    "flag":        "is_redacted",
+    "value":       true,
+    "metadata":    { ... full updated metadata map ... }
+}
+
+Storage: writes through `ai_reports_store.update_metadata` with
+`{flag: "true" | "false"}` — booleans persist as strings because the
+flat-map accessor on iOS (`AIReport.metadata: [String: String]`)
+collapses Dynamo BOOL to "true"/"false" already.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common import ai_reports_store
+from lambdas.common.admin_gate import NotAdmin, require_admin
+from lambdas.common.errors import XomperError, handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import parse_body, success_response
+
+log = get_logger(__file__)
+HANDLER = "api_admin_reports_flag"
+
+ALLOWED_FLAGS: tuple[str, ...] = ("is_redacted", "do_not_broadcast")
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    log.info("Admin reports-flag request")
+
+    body = parse_body(event)
+
+    try:
+        admin_user = require_admin(event, body)
+    except NotAdmin:
+        return success_response(
+            {"Success": False, "Message": "Not authorized"},
+            status_code=403,
+        )
+
+    league_id = (body.get("league_id") or "").strip()
+    report_type = (body.get("report_type") or "").strip()
+    period = (body.get("period") or "").strip()
+    flag = (body.get("flag") or "").strip()
+    raw_value = body.get("value")
+
+    # --- input validation ---------------------------------------------------
+    if not league_id:
+        return success_response(
+            {"Success": False, "Message": "Missing 'league_id' in body"},
+            status_code=400,
+        )
+    if not report_type:
+        return success_response(
+            {"Success": False, "Message": "Missing 'report_type' in body"},
+            status_code=400,
+        )
+    if not period:
+        return success_response(
+            {"Success": False, "Message": "Missing 'period' in body"},
+            status_code=400,
+        )
+    if not flag:
+        return success_response(
+            {"Success": False, "Message": "Missing 'flag' in body"},
+            status_code=400,
+        )
+    if flag not in ALLOWED_FLAGS:
+        return success_response(
+            {
+                "Success": False,
+                "Message": (
+                    f"Invalid flag '{flag}'. "
+                    f"Must be one of {list(ALLOWED_FLAGS)}."
+                ),
+            },
+            status_code=400,
+        )
+    if not isinstance(raw_value, bool):
+        return success_response(
+            {
+                "Success": False,
+                "Message": "'value' must be a boolean (true/false)",
+            },
+            status_code=400,
+        )
+
+    # --- existence check ----------------------------------------------------
+    # 404 immediately rather than blind-writing a metadata patch on a
+    # nonexistent row (UpdateItem would otherwise create a partial row
+    # with only `metadata.<flag>` set, leaving an inconsistent record).
+    try:
+        report = ai_reports_store.get_report(
+            league_id=league_id,
+            report_type=report_type,
+            period=period,
+        )
+    except XomperError as err:
+        err.log_error()
+        return err.to_response()
+
+    if not report:
+        return success_response(
+            {
+                "Success": False,
+                "Message": (
+                    f"Report not found for league={league_id} "
+                    f"type={report_type} period={period}"
+                ),
+            },
+            status_code=404,
+        )
+
+    # --- mutate -------------------------------------------------------------
+    value_str = "true" if raw_value else "false"
+    try:
+        updated_item = ai_reports_store.update_metadata(
+            league_id=league_id,
+            report_type=report_type,
+            period=period,
+            partial={flag: value_str},
+        )
+    except XomperError as err:
+        err.log_error()
+        return err.to_response()
+
+    metadata = updated_item.get("metadata") if isinstance(updated_item, dict) else None
+
+    # TODO(F4): audit_log_write — capture (actor_sleeper_id, flag,
+    # value, target_report_id, ts) into the `admin_audit` Supabase
+    # table. F4 ships the table + retrofits this lambda + the F1
+    # admin-portal lambdas. For now the orchestrators rely on Dynamo
+    # metadata + CloudWatch logs as a poor-man's audit trail.
+    actor = admin_user.get("sleeper_user_id") or admin_user.get("id")
+    log.info(
+        f"admin_reports_flag: actor={actor} league={league_id} "
+        f"type={report_type} period={period} flag={flag} value={raw_value}"
+    )
+
+    return success_response(
+        {
+            "Success": True,
+            "league_id": league_id,
+            "report_type": report_type,
+            "period": period,
+            "flag": flag,
+            "value": raw_value,
+            "metadata": metadata or {},
+        }
+    )

--- a/lambdas/api_ai_reports_latest/handler.py
+++ b/lambdas/api_ai_reports_latest/handler.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from lambdas.common.admin_gate import is_admin
 from lambdas.common.ai_reports_store import REPORT_TYPES, get_latest
 from lambdas.common.errors import handle_errors
 from lambdas.common.logger import get_logger
@@ -72,4 +73,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
 
     report = get_latest(league_id, report_type)
+
+    # Admin-portal F3: hide redacted reports from non-admin callers.
+    # Admins still see the row (the iOS archive surfaces a "Show
+    # redacted" toggle so they can un-redact). Treat the redacted-
+    # for-non-admin case as "no report" so the iOS empty-state path
+    # is identical to the no-row case — no info leak about the row's
+    # existence.
+    if report and not is_admin(event):
+        metadata = report.get("metadata") or {}
+        if str(metadata.get("is_redacted", "")).lower() == "true":
+            report = None
+
     return success_response({"report": report})

--- a/lambdas/api_ai_reports_list/handler.py
+++ b/lambdas/api_ai_reports_list/handler.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from lambdas.common.admin_gate import is_admin
 from lambdas.common.ai_reports_store import REPORT_TYPES, list_recent
 from lambdas.common.errors import handle_errors
 from lambdas.common.logger import get_logger
@@ -82,6 +83,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
             status_code=500,
         )
 
+    # Admin-portal F3: non-admin callers never see redacted rows.
+    # Resolved once per request and threaded through the post-query
+    # filter below.
+    caller_is_admin = is_admin(event)
+
+    def _is_redacted(row: dict[str, Any]) -> bool:
+        meta = row.get("metadata") or {}
+        return str(meta.get("is_redacted", "")).lower() == "true"
+
     # When filtering by type we may need to walk a few pages to fill
     # one page of `limit` rows since Dynamo applies `Limit` before
     # the in-process filter. Cap the walk so a sparse type doesn't
@@ -99,13 +109,14 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         )
         pages += 1
 
-        if report_type is None:
-            collected.extend(items)
-        else:
-            collected.extend(
-                row for row in items
-                if (row.get("report_type") or "") == report_type
-            )
+        for row in items:
+            # Type filter (when set) AND redact filter (when caller
+            # is not admin).
+            if report_type is not None and (row.get("report_type") or "") != report_type:
+                continue
+            if not caller_is_admin and _is_redacted(row):
+                continue
+            collected.append(row)
 
         if len(collected) >= limit or next_cursor is None:
             break

--- a/lambdas/common/admin_gate.py
+++ b/lambdas/common/admin_gate.py
@@ -85,3 +85,39 @@ def require_admin(event: dict[str, Any], body: dict[str, Any] | None = None) -> 
         raise NotAdmin("not authorized")
 
     return user
+
+
+def is_admin(event: dict[str, Any], body: dict[str, Any] | None = None) -> bool:
+    """Non-raising sibling of `require_admin`.
+
+    Returns True when the resolved caller exists in `whitelisted_users`
+    AND has `is_admin == true`. Returns False in every other case —
+    missing identifier, unknown user, non-admin user, or any lookup
+    error. Used by read-path endpoints
+    (`api_ai_reports_latest`, `api_ai_reports_list`) to branch the
+    redact filter without polluting the happy-path response with
+    admin-gate exceptions: non-admin callers are still served, just
+    with redacted rows filtered out.
+    """
+    try:
+        sleeper_id, email = resolve_caller_identity(event, body)
+    except Exception as err:  # noqa: BLE001 — read paths never fail on identity
+        log.warning(f"admin_gate.is_admin: identity resolution failed: {err}")
+        return False
+
+    if not sleeper_id and not email:
+        return False
+
+    try:
+        user: dict[str, Any] | None = None
+        if sleeper_id:
+            user = get_whitelisted_user_by_sleeper_id(sleeper_id)
+        if not user and email:
+            user = get_whitelisted_user_by_email(email)
+    except Exception as err:  # noqa: BLE001 — read paths never fail on lookup
+        log.warning(f"admin_gate.is_admin: lookup failed: {err}")
+        return False
+
+    if not user:
+        return False
+    return bool(user.get("is_admin"))

--- a/lambdas/common/ai_reports_store.py
+++ b/lambdas/common/ai_reports_store.py
@@ -315,6 +315,35 @@ def update_metadata(
     return response.get("Attributes", {})
 
 
+def stamp_broadcast_at(
+    league_id: str,
+    report_type: str,
+    period: str,
+) -> dict[str, Any]:
+    """Stamp `metadata.broadcast_at = <utc iso8601>` on the report row.
+
+    Canonical single-write helper for the broadcast-success path —
+    called by all three orchestrators (postdraft, preseason, weekly)
+    after `send_emails_concurrently` returns. Keeps the timestamp
+    format identical across report types so the iOS surface can
+    parse a single shape.
+
+    Returns:
+        The updated item (mirrors `update_metadata`).
+
+    Raises:
+        ValidationError: invalid report_type / empty inputs.
+        DynamoDBError: on Dynamo failure.
+    """
+    broadcast_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return update_metadata(
+        league_id=league_id,
+        report_type=report_type,
+        period=period,
+        partial={"broadcast_at": broadcast_at},
+    )
+
+
 def list_recent(
     league_id: str,
     limit: int = 20,

--- a/lambdas/common/errors.py
+++ b/lambdas/common/errors.py
@@ -218,6 +218,42 @@ class PreseasonWindowPassedError(XomperError):
         )
 
 
+class DoNotBroadcastError(XomperError):
+    """Raised when an AI Review broadcast path attempts to fan out a
+    report whose `metadata.do_not_broadcast == "true"` flag is set.
+
+    Surfaces as HTTP 409 (Conflict) so the admin client can flip the
+    Broadcast button label and message the user that the flag must be
+    toggled off before sending. Distinct from
+    `ReportAlreadyExistsError` (same status code) so the iOS surface
+    can render a tailored error string.
+    """
+
+    def __init__(
+        self,
+        message: str = (
+            "Report is marked do_not_broadcast. "
+            "Toggle the flag off to broadcast."
+        ),
+        handler: str = "ai_reports_broadcast",
+        function: str = "run",
+        report_type: Optional[str] = None,
+        period: Optional[str] = None,
+    ):
+        details: dict = {}
+        if report_type:
+            details["report_type"] = report_type
+        if period:
+            details["period"] = period
+        super().__init__(
+            message=message,
+            handler=handler,
+            function=function,
+            status=409,
+            details=details,
+        )
+
+
 class ReportAlreadyExistsError(XomperError):
     """Raised when an AI Review report already exists for a given
     `(league_id, report_type, period)` and the caller did not pass

--- a/lambdas/common/weekly_orchestrator.py
+++ b/lambdas/common/weekly_orchestrator.py
@@ -34,7 +34,6 @@ Returns a dict suitable for JSON-encoding in the API response.
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from typing import Any
 
 from lambdas.common import (
@@ -56,6 +55,7 @@ from lambdas.common.email_templates.ai_review import (
     render_preview_for_user,
 )
 from lambdas.common.errors import (
+    DoNotBroadcastError,
     NotFoundError,
     ReportAlreadyExistsError,
     ValidationError,
@@ -395,6 +395,14 @@ def run_weekly(
                     f"memory_count_out failed: {err}"
                 )
 
+    # --- pre-broadcast DNB check (Admin Portal F3) ---------------------------
+    # Re-read the row right before SES fan-out so admins who flipped
+    # `do_not_broadcast=true` AFTER generation but BEFORE broadcast
+    # still get the abort. Dry-run path skips — locking only matters
+    # for real-broadcast attempts.
+    if not dry_run:
+        _enforce_not_dnb(league_id=league_id, period=period)
+
     # --- deliver -------------------------------------------------------------
     delivery_count = _deliver(
         dry_run=dry_run,
@@ -420,24 +428,23 @@ def run_weekly(
             f"users (dry_run=true, week={resolved_week})"
         )
 
-    # --- stamp broadcast_at on broadcast path --------------------------------
+    # --- stamp broadcast_at on broadcast path AFTER SES success --------------
+    # Partial-failure safe: only runs if `_deliver` returned without
+    # raising. Uses the canonical helper so all three orchestrators
+    # write the same key with the same format.
     if not dry_run:
-        broadcast_at = datetime.now(timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
         try:
-            ai_reports_store.update_metadata(
+            updated = ai_reports_store.stamp_broadcast_at(
                 league_id=league_id,
                 report_type=REPORT_TYPE,
                 period=period,
-                partial={"broadcast_at": broadcast_at},
             )
-            metadata["broadcast_at"] = broadcast_at
-            report_row["metadata"] = metadata
+            if isinstance(updated, dict) and updated.get("metadata"):
+                metadata.update(updated["metadata"])
+                report_row["metadata"] = metadata
         except Exception as err:  # noqa: BLE001 — non-blocking
             log.warning(
-                f"notif_ai_review_weekly: update_metadata "
-                f"broadcast_at failed: {err}"
+                f"notif_ai_review_weekly: stamp_broadcast_at failed: {err}"
             )
 
     status = "dry_run_sent" if dry_run else "broadcast"
@@ -466,6 +473,32 @@ def run_weekly(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _enforce_not_dnb(*, league_id: str, period: str) -> None:
+    """Re-read the just-written report row and raise
+    `DoNotBroadcastError` (HTTP 409) when `metadata.do_not_broadcast`
+    is truthy. Called immediately before SES fan-out on the real-
+    broadcast path only — dry-run delivery is unaffected.
+
+    Cheap: one Dynamo `get_item`. Catches the race where an admin
+    flips DNB on between `write_report` and the broadcast attempt.
+    """
+    fresh = ai_reports_store.get_report(
+        league_id=league_id,
+        report_type=REPORT_TYPE,
+        period=period,
+    )
+    if not fresh:
+        return
+    meta = fresh.get("metadata") or {}
+    flag = meta.get("do_not_broadcast")
+    if flag is True or (isinstance(flag, str) and flag.lower() == "true"):
+        raise DoNotBroadcastError(
+            handler="notif_ai_review_weekly",
+            report_type=REPORT_TYPE,
+            period=period,
+        )
 
 
 def _resolve_week(*, week: int | None, nfl_week: Any) -> int:

--- a/tests/test_admin_gate_is_admin.py
+++ b/tests/test_admin_gate_is_admin.py
@@ -1,0 +1,129 @@
+"""
+Tests for `lambdas.common.admin_gate.is_admin` (admin-portal F3).
+
+`is_admin` is the non-raising sibling of `require_admin`. The read-
+path endpoints (`api_ai_reports_latest`, `api_ai_reports_list`) use
+it to branch the `is_redacted` filter without breaking the
+happy-path response for non-admin callers.
+
+Covers:
+  - Returns True when the resolved user has `is_admin = True`.
+  - Returns False when the resolved user has `is_admin = False`.
+  - Returns False when no caller identifier is supplied.
+  - Returns False when the supabase lookup returns None.
+  - Returns False when the supabase lookup raises (defensive — read
+    paths should never fail because the admin lookup hiccuped).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "admin-id-123"
+NON_ADMIN_ID = "u7"
+
+
+def _event(*, sleeper_user_id: str | None = None, email: str | None = None) -> dict[str, Any]:
+    headers: dict[str, str] = {}
+    if sleeper_user_id:
+        headers["X-Sleeper-User-Id"] = sleeper_user_id
+    if email:
+        headers["X-User-Email"] = email
+    return {"httpMethod": "GET", "headers": headers}
+
+
+class TestIsAdmin:
+    def test_returns_true_for_admin_caller(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        def _by_sleeper(sleeper_id: str):
+            return {"id": "row-admin", "sleeper_user_id": sleeper_id, "is_admin": True}
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", _by_sleeper
+        )
+        assert admin_gate.is_admin(_event(sleeper_user_id=ADMIN_ID)) is True
+
+    def test_returns_false_for_non_admin_caller(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        def _by_sleeper(sleeper_id: str):
+            return {"id": "row-u7", "sleeper_user_id": sleeper_id, "is_admin": False}
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", _by_sleeper
+        )
+        assert admin_gate.is_admin(_event(sleeper_user_id=NON_ADMIN_ID)) is False
+
+    def test_returns_false_when_no_identifier(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        # Lookup should never run with no identifier present.
+        def _fail(*args, **kwargs):  # pragma: no cover — should not be called
+            raise AssertionError("lookup invoked despite missing identity")
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", _fail
+        )
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_email", _fail
+        )
+        assert admin_gate.is_admin({"httpMethod": "GET", "headers": {}}) is False
+
+    def test_returns_false_when_user_not_found(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", lambda sid: None
+        )
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_email", lambda em: None
+        )
+        assert admin_gate.is_admin(_event(sleeper_user_id="ghost")) is False
+
+    def test_returns_false_when_lookup_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("supabase down")
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", _raise
+        )
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_email", _raise
+        )
+        # Read-paths must never raise on identity lookup hiccups — they
+        # just degrade to non-admin behavior (filter redacted out).
+        assert admin_gate.is_admin(_event(sleeper_user_id=ADMIN_ID)) is False
+
+    def test_falls_back_to_email_when_sleeper_id_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import admin_gate
+
+        def _by_sleeper(sleeper_id: str):  # pragma: no cover — not invoked
+            return None
+
+        def _by_email(email: str):
+            return {"id": "row-admin", "email": email, "is_admin": True}
+
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_sleeper_id", _by_sleeper
+        )
+        monkeypatch.setattr(
+            admin_gate, "get_whitelisted_user_by_email", _by_email
+        )
+        assert admin_gate.is_admin(_event(email="admin@example.com")) is True

--- a/tests/test_ai_reports_store.py
+++ b/tests/test_ai_reports_store.py
@@ -196,6 +196,42 @@ class TestGetLatest:
             store.get_latest("L1", "bogus")
 
 
+class TestStampBroadcastAt:
+    """`stamp_broadcast_at` is the canonical helper called by all three
+    broadcast orchestrators (admin-portal F3). Asserts it writes the
+    `broadcast_at` key into the existing `metadata` map with an ISO-
+    8601 UTC string."""
+
+    def test_stamps_broadcast_at_into_metadata(self, dynamo_table) -> None:
+        store = dynamo_table
+        _put_report(
+            store, "L1", "weekly", "2026W04",
+            metadata={"model": "claude-haiku-4-5"},
+        )
+
+        store.stamp_broadcast_at("L1", "weekly", "2026W04")
+
+        updated = store.get_latest("L1", "weekly")
+        assert updated is not None
+        meta = updated.get("metadata") or {}
+        stamp = meta.get("broadcast_at")
+        assert isinstance(stamp, str)
+        # ISO-8601 UTC with trailing Z (matches the existing inline
+        # format) — gates the wire shape so the iOS Date parser keeps
+        # working.
+        assert stamp.endswith("Z")
+        assert "T" in stamp
+        # Pre-existing metadata is preserved through the merge.
+        assert meta["model"] == "claude-haiku-4-5"
+
+    def test_invalid_report_type_raises(self, dynamo_table) -> None:
+        store = dynamo_table
+        from lambdas.common.errors import ValidationError
+
+        with pytest.raises(ValidationError):
+            store.stamp_broadcast_at("L1", "bogus", "2026W04")
+
+
 class TestListRecent:
     def test_newest_first_across_types(self, dynamo_table) -> None:
         store = dynamo_table

--- a/tests/test_api_admin_ai_review_postdraft_trigger.py
+++ b/tests/test_api_admin_ai_review_postdraft_trigger.py
@@ -248,9 +248,37 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         )
         return {}
 
+    def _get_report(*, league_id, report_type, period):
+        # Re-read after write returns the latest item the orchestrator
+        # just persisted (so the DNB pre-broadcast check sees the same
+        # row). Honor a per-test override via `state["fresh_metadata"]`
+        # for the DNB-set case.
+        override = state.get("fresh_metadata")
+        if override is not None:
+            base = (
+                state["writes"][-1]
+                if state["writes"]
+                else {"metadata": {}}
+            )
+            return {**base, "metadata": {**(base.get("metadata") or {}), **override}}
+        return state["writes"][-1] if state["writes"] else None
+
+    def _stamp_broadcast_at(*, league_id, report_type, period):
+        # Mirrors `ai_reports_store.stamp_broadcast_at` — routes to
+        # the test's `_update_metadata` so existing assertions on the
+        # `metadata_updates` list still see the broadcast_at key.
+        return _update_metadata(
+            league_id=league_id,
+            report_type=report_type,
+            period=period,
+            partial={"broadcast_at": "2026-05-21T15:30:00Z"},
+        )
+
     fake_store.get_latest = _get_latest
+    fake_store.get_report = _get_report
     fake_store.write_report = _write_report
     fake_store.update_metadata = _update_metadata
+    fake_store.stamp_broadcast_at = _stamp_broadcast_at
     monkeypatch.setattr(orchestrator, "ai_reports_store", fake_store)
 
     # claude_helper

--- a/tests/test_api_admin_ai_review_preseason_trigger.py
+++ b/tests/test_api_admin_ai_review_preseason_trigger.py
@@ -185,9 +185,30 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         )
         return {}
 
+    def _get_report(*, league_id, report_type, period):
+        override = state.get("fresh_metadata")
+        if override is not None:
+            base = (
+                state["writes"][-1]
+                if state["writes"]
+                else {"metadata": {}}
+            )
+            return {**base, "metadata": {**(base.get("metadata") or {}), **override}}
+        return state["writes"][-1] if state["writes"] else None
+
+    def _stamp_broadcast_at(*, league_id, report_type, period):
+        return _update_metadata(
+            league_id=league_id,
+            report_type=report_type,
+            period=period,
+            partial={"broadcast_at": "2026-08-30T15:30:00Z"},
+        )
+
     fake_store.get_latest = _get_latest
+    fake_store.get_report = _get_report
     fake_store.write_report = _write_report
     fake_store.update_metadata = _update_metadata
+    fake_store.stamp_broadcast_at = _stamp_broadcast_at
     monkeypatch.setattr(orchestrator, "ai_reports_store", fake_store)
 
     # claude_helper

--- a/tests/test_api_admin_ai_review_weekly_trigger.py
+++ b/tests/test_api_admin_ai_review_weekly_trigger.py
@@ -279,9 +279,30 @@ def patched_orchestrator(monkeypatch: pytest.MonkeyPatch):
         )
         return {}
 
+    def _get_report(*, league_id, report_type, period):
+        override = state.get("fresh_metadata")
+        if override is not None:
+            base = (
+                state["writes"][-1]
+                if state["writes"]
+                else {"metadata": {}}
+            )
+            return {**base, "metadata": {**(base.get("metadata") or {}), **override}}
+        return state["writes"][-1] if state["writes"] else None
+
+    def _stamp_broadcast_at(*, league_id, report_type, period):
+        return _update_metadata(
+            league_id=league_id,
+            report_type=report_type,
+            period=period,
+            partial={"broadcast_at": "2026-09-10T18:30:00Z"},
+        )
+
     fake_reports.get_latest = _get_latest
+    fake_reports.get_report = _get_report
     fake_reports.write_report = _write_report
     fake_reports.update_metadata = _update_metadata
+    fake_reports.stamp_broadcast_at = _stamp_broadcast_at
     monkeypatch.setattr(orch, "ai_reports_store", fake_reports)
 
     # ai_memories_store

--- a/tests/test_api_admin_reports_flag.py
+++ b/tests/test_api_admin_reports_flag.py
@@ -1,0 +1,402 @@
+"""
+Tests for `api_admin_reports_flag` (admin-portal F3).
+
+Endpoint shape: POST /admin/reports-flag, body
+  { league_id, report_type, period, flag, value }
+
+Covers:
+  - 403 when the caller is not an admin.
+  - 400 on missing fields (league_id, report_type, period, flag, value).
+  - 400 on invalid flag name (anything other than `is_redacted` /
+    `do_not_broadcast`).
+  - 400 when `value` is not a real bool (e.g. "yes" string, int).
+  - 404 when the target report doesn't exist.
+  - Happy path: both allowed flags toggle through and the response
+    carries the FULL updated metadata blob.
+  - Round-trip: set then unset writes the expected string values.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+LEAGUE_ID = "LEAGUE_ID"
+
+
+def _api_event(
+    *,
+    body: dict[str, Any] | None = None,
+    sleeper_user_id: str | None = ADMIN_ID,
+) -> dict[str, Any]:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "POST",
+        "path": "/admin/reports-flag",
+        "headers": headers,
+        "body": json.dumps(body or {}),
+    }
+
+
+def _admin_row() -> dict[str, Any]:
+    return {
+        "id": "row-admin",
+        "sleeper_user_id": ADMIN_ID,
+        "email": "admin@example.com",
+        "display_name": "Admin Dom",
+        "is_active": True,
+        "is_admin": True,
+    }
+
+
+def _report_row() -> dict[str, Any]:
+    return {
+        "pk": f"LEAGUE#{LEAGUE_ID}",
+        "sk": "REPORT#weekly#2026W04",
+        "league_id": LEAGUE_ID,
+        "report_type": "weekly",
+        "period": "2026W04",
+        "body_markdown": "# Weekly recap\n\nWeek 4.\n",
+        "metadata": {"model": "claude-haiku-4-5"},
+        "created_at": "2026-10-01T15:00:00Z",
+    }
+
+
+@pytest.fixture
+def patched_handler(monkeypatch: pytest.MonkeyPatch):
+    """Wire every external seam the handler touches. Returns the
+    mutable `state` dict so tests can flip individual hooks (e.g.
+    drop the report to hit the 404 path)."""
+    from lambdas.api_admin_reports_flag import handler as h
+
+    state: dict[str, Any] = {
+        "admin_row": _admin_row(),
+        "report_row": _report_row(),
+        # Each invocation of `update_metadata` appends one entry here.
+        "metadata_writes": [],
+    }
+
+    def _require_admin(event, body=None):
+        return state["admin_row"]
+
+    def _get_report(*, league_id, report_type, period):
+        canned = state["report_row"]
+        if canned is None:
+            return None
+        if (
+            league_id == canned["league_id"]
+            and report_type == canned["report_type"]
+            and period == canned["period"]
+        ):
+            return canned
+        return None
+
+    def _update_metadata(*, league_id, report_type, period, partial):
+        # Mutate the canned row's metadata so the round-trip test can
+        # observe the merged shape.
+        if state["report_row"] is not None:
+            state["report_row"]["metadata"].update(partial)
+        state["metadata_writes"].append(
+            {
+                "league_id": league_id,
+                "report_type": report_type,
+                "period": period,
+                "partial": partial,
+            }
+        )
+        return {
+            "pk": f"LEAGUE#{league_id}",
+            "sk": f"REPORT#{report_type}#{period}",
+            "league_id": league_id,
+            "report_type": report_type,
+            "period": period,
+            "metadata": dict(
+                (state["report_row"] or {}).get("metadata") or {}
+            ),
+        }
+
+    monkeypatch.setattr(h, "require_admin", _require_admin)
+    monkeypatch.setattr(h.ai_reports_store, "get_report", _get_report)
+    monkeypatch.setattr(h.ai_reports_store, "update_metadata", _update_metadata)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestAdminGate:
+    def test_non_admin_returns_403(
+        self,
+        patched_handler,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+        from lambdas.common.admin_gate import NotAdmin
+
+        def _raise(event, body=None):
+            raise NotAdmin("not authorized")
+
+        monkeypatch.setattr(h, "require_admin", _raise)
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 403
+        body = json.loads(response["body"])
+        assert body["Success"] is False
+        # No metadata write occurred.
+        assert patched_handler["metadata_writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    @pytest.mark.parametrize(
+        "missing_field,body",
+        [
+            (
+                "league_id",
+                {"report_type": "weekly", "period": "2026W04", "flag": "is_redacted", "value": True},
+            ),
+            (
+                "report_type",
+                {"league_id": LEAGUE_ID, "period": "2026W04", "flag": "is_redacted", "value": True},
+            ),
+            (
+                "period",
+                {"league_id": LEAGUE_ID, "report_type": "weekly", "flag": "is_redacted", "value": True},
+            ),
+            (
+                "flag",
+                {"league_id": LEAGUE_ID, "report_type": "weekly", "period": "2026W04", "value": True},
+            ),
+        ],
+    )
+    def test_missing_field_returns_400(
+        self, patched_handler, missing_field: str, body: dict[str, Any]
+    ) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(_api_event(body=body), context=None)
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert missing_field in parsed["Message"]
+        assert patched_handler["metadata_writes"] == []
+
+    def test_missing_value_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    # value omitted -> None -> 400
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "value" in parsed["Message"].lower()
+
+    def test_unknown_flag_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "bogus_flag",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "bogus_flag" in parsed["Message"]
+        assert patched_handler["metadata_writes"] == []
+
+    def test_non_bool_value_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": "yes",  # not a real bool
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "bool" in parsed["Message"].lower()
+        assert patched_handler["metadata_writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Lookup failures
+# ---------------------------------------------------------------------------
+
+
+class TestLookupFailures:
+    def test_unknown_report_returns_404(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        patched_handler["report_row"] = None  # drop the canned row
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 404
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "not found" in parsed["Message"].lower()
+        assert patched_handler["metadata_writes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_set_is_redacted_true(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is True
+        assert parsed["league_id"] == LEAGUE_ID
+        assert parsed["report_type"] == "weekly"
+        assert parsed["period"] == "2026W04"
+        assert parsed["flag"] == "is_redacted"
+        assert parsed["value"] is True
+        # Persists as string "true" so the iOS flat-map accessor reads
+        # it back identically to the Dynamo BOOL collapse.
+        assert parsed["metadata"]["is_redacted"] == "true"
+        # Existing metadata keys preserved through the merge.
+        assert parsed["metadata"]["model"] == "claude-haiku-4-5"
+
+        # Exactly one update_metadata call with the expected partial.
+        assert len(patched_handler["metadata_writes"]) == 1
+        write = patched_handler["metadata_writes"][0]
+        assert write["partial"] == {"is_redacted": "true"}
+
+    def test_set_do_not_broadcast_true(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        response = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "do_not_broadcast",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is True
+        assert parsed["flag"] == "do_not_broadcast"
+        assert parsed["metadata"]["do_not_broadcast"] == "true"
+        write = patched_handler["metadata_writes"][0]
+        assert write["partial"] == {"do_not_broadcast": "true"}
+
+    def test_round_trip_set_then_unset(self, patched_handler) -> None:
+        from lambdas.api_admin_reports_flag import handler as h
+
+        # Set
+        resp1 = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": True,
+                }
+            ),
+            context=None,
+        )
+        assert resp1["statusCode"] == 200
+        parsed1 = json.loads(resp1["body"])
+        assert parsed1["metadata"]["is_redacted"] == "true"
+
+        # Unset
+        resp2 = h.handler(
+            _api_event(
+                body={
+                    "league_id": LEAGUE_ID,
+                    "report_type": "weekly",
+                    "period": "2026W04",
+                    "flag": "is_redacted",
+                    "value": False,
+                }
+            ),
+            context=None,
+        )
+        assert resp2["statusCode"] == 200
+        parsed2 = json.loads(resp2["body"])
+        assert parsed2["metadata"]["is_redacted"] == "false"
+
+        # Two writes; first set, second unset.
+        writes = patched_handler["metadata_writes"]
+        assert len(writes) == 2
+        assert writes[0]["partial"] == {"is_redacted": "true"}
+        assert writes[1]["partial"] == {"is_redacted": "false"}

--- a/tests/test_api_ai_reports_redact_filter.py
+++ b/tests/test_api_ai_reports_redact_filter.py
@@ -1,0 +1,232 @@
+"""
+Read-path redact-filter tests (admin-portal F3).
+
+Covers:
+  - `api_ai_reports_latest` returns the row to an admin caller even
+    when `metadata.is_redacted == "true"`.
+  - `api_ai_reports_latest` returns `report = None` (200 OK, the iOS
+    empty-state path) to a non-admin caller when the row is redacted.
+  - `api_ai_reports_list` includes redacted rows for admin callers.
+  - `api_ai_reports_list` filters redacted rows out for non-admin
+    callers, leaving the rest of the response shape stable.
+
+External integrations (Supabase, DynamoDB ai_reports_store) are
+monkeypatched.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+NON_ADMIN_ID = "u7"
+LEAGUE_ID = "LEAGUE_ID"
+
+
+def _event(*, sleeper_user_id: str | None = None, qs: dict[str, str] | None = None) -> dict[str, Any]:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "GET",
+        "headers": headers,
+        "queryStringParameters": qs or {},
+    }
+
+
+def _row(
+    *,
+    sk: str = "REPORT#weekly#2026W04",
+    report_type: str = "weekly",
+    period: str = "2026W04",
+    redacted: bool = False,
+    extra_meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    meta: dict[str, Any] = {"model": "claude-haiku-4-5"}
+    if redacted:
+        meta["is_redacted"] = "true"
+    if extra_meta:
+        meta.update(extra_meta)
+    return {
+        "pk": f"LEAGUE#{LEAGUE_ID}",
+        "sk": sk,
+        "league_id": LEAGUE_ID,
+        "report_type": report_type,
+        "period": period,
+        "body_markdown": f"# {report_type} {period}\n",
+        "metadata": meta,
+        "created_at": "2026-10-01T15:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# `api_ai_reports_latest`
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_latest(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.api_ai_reports_latest import handler as h
+
+    state: dict[str, Any] = {
+        "report": _row(redacted=True),
+        "is_admin_response": False,
+    }
+
+    monkeypatch.setattr(
+        h,
+        "get_active_whitelisted_league",
+        lambda: {"sleeper_league_id": LEAGUE_ID, "league_name": "CLT"},
+    )
+    monkeypatch.setattr(h, "get_latest", lambda lid, rt: state["report"])
+    monkeypatch.setattr(h, "is_admin", lambda event: state["is_admin_response"])
+
+    return state
+
+
+class TestLatestRedactFilter:
+    def test_admin_sees_redacted_report(self, patched_latest) -> None:
+        from lambdas.api_ai_reports_latest import handler as h
+
+        patched_latest["is_admin_response"] = True
+        response = h.handler(
+            _event(sleeper_user_id=ADMIN_ID, qs={"type": "weekly"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["report"] is not None
+        assert body["report"]["metadata"]["is_redacted"] == "true"
+
+    def test_non_admin_gets_null_for_redacted_report(
+        self, patched_latest
+    ) -> None:
+        from lambdas.api_ai_reports_latest import handler as h
+
+        patched_latest["is_admin_response"] = False
+        response = h.handler(
+            _event(sleeper_user_id=NON_ADMIN_ID, qs={"type": "weekly"}),
+            context=None,
+        )
+        # 200 + null `report` so the iOS empty-state path is shared
+        # with the legitimate "no row exists yet" case. No info leak.
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["report"] is None
+
+    def test_non_admin_sees_non_redacted_report(
+        self, patched_latest
+    ) -> None:
+        from lambdas.api_ai_reports_latest import handler as h
+
+        patched_latest["report"] = _row(redacted=False)
+        patched_latest["is_admin_response"] = False
+        response = h.handler(
+            _event(sleeper_user_id=NON_ADMIN_ID, qs={"type": "weekly"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["report"] is not None
+        assert body["report"]["report_type"] == "weekly"
+
+
+# ---------------------------------------------------------------------------
+# `api_ai_reports_list`
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_list(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.api_ai_reports_list import handler as h
+
+    # 4 rows total; #2 and #4 are redacted.
+    rows = [
+        _row(sk="REPORT#weekly#2026W04", report_type="weekly", period="2026W04", redacted=False),
+        _row(sk="REPORT#weekly#2026W03", report_type="weekly", period="2026W03", redacted=True),
+        _row(sk="REPORT#weekly#2026W02", report_type="weekly", period="2026W02", redacted=False),
+        _row(sk="REPORT#weekly#2026W01", report_type="weekly", period="2026W01", redacted=True),
+    ]
+
+    state: dict[str, Any] = {
+        "rows": rows,
+        "is_admin_response": False,
+    }
+
+    monkeypatch.setattr(
+        h,
+        "get_active_whitelisted_league",
+        lambda: {"sleeper_league_id": LEAGUE_ID, "league_name": "CLT"},
+    )
+
+    def _list_recent(*, league_id, limit, cursor=None):
+        return list(state["rows"]), None
+
+    monkeypatch.setattr(h, "list_recent", _list_recent)
+    monkeypatch.setattr(h, "is_admin", lambda event: state["is_admin_response"])
+
+    return state
+
+
+class TestListRedactFilter:
+    def test_admin_sees_all_rows_including_redacted(self, patched_list) -> None:
+        from lambdas.api_ai_reports_list import handler as h
+
+        patched_list["is_admin_response"] = True
+        response = h.handler(
+            _event(sleeper_user_id=ADMIN_ID, qs={"limit": "10"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert len(body["rows"]) == 4
+        # The two redacted rows are present.
+        redacted = [r for r in body["rows"] if r["metadata"].get("is_redacted") == "true"]
+        assert len(redacted) == 2
+
+    def test_non_admin_redacted_rows_filtered_out(self, patched_list) -> None:
+        from lambdas.api_ai_reports_list import handler as h
+
+        patched_list["is_admin_response"] = False
+        response = h.handler(
+            _event(sleeper_user_id=NON_ADMIN_ID, qs={"limit": "10"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        # Only the 2 non-redacted rows.
+        assert len(body["rows"]) == 2
+        for row in body["rows"]:
+            assert row["metadata"].get("is_redacted") != "true"
+
+    def test_non_admin_type_filter_combines_with_redact_filter(
+        self, patched_list
+    ) -> None:
+        from lambdas.api_ai_reports_list import handler as h
+
+        # Add a post-draft row to confirm type filter still narrows.
+        patched_list["rows"].append(
+            _row(
+                sk="REPORT#postDraft#2026",
+                report_type="postDraft",
+                period="2026",
+                redacted=False,
+            )
+        )
+        patched_list["is_admin_response"] = False
+        response = h.handler(
+            _event(
+                sleeper_user_id=NON_ADMIN_ID,
+                qs={"limit": "10", "type": "weekly"},
+            ),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        # Only non-redacted weekly rows.
+        assert len(body["rows"]) == 2
+        assert all(r["report_type"] == "weekly" for r in body["rows"])
+        assert all(
+            r["metadata"].get("is_redacted") != "true" for r in body["rows"]
+        )

--- a/tests/test_orchestrator_broadcast_at_stamp.py
+++ b/tests/test_orchestrator_broadcast_at_stamp.py
@@ -1,0 +1,149 @@
+"""
+Cross-orchestrator broadcast_at-stamp tests (admin-portal F3).
+
+Asserts the canonical broadcast-success stamp pattern across all
+three orchestrators (post-draft, preseason, weekly):
+
+  - `dry_run=False` + successful SES fan-out -> `stamp_broadcast_at`
+    is called exactly once.
+  - `dry_run=False` + SES raises -> NO stamp written. Partial-failure
+    safety: a fan-out that blew up halfway through must NOT mark the
+    report as broadcast.
+  - `dry_run=True` -> stamp helper is never called regardless of
+    delivery success (dry-run isn't a broadcast).
+
+Re-uses the existing fixtures via pytest import (same shape as
+`test_orchestrator_dnb_abort.py`).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.test_api_admin_ai_review_postdraft_trigger import (  # noqa: F401
+    patched_orchestrator as patched_postdraft,
+)
+from tests.test_api_admin_ai_review_preseason_trigger import (  # noqa: F401
+    patched_orchestrator as patched_preseason,
+)
+from tests.test_api_admin_ai_review_weekly_trigger import (  # noqa: F401
+    patched_orchestrator as patched_weekly,
+)
+
+
+def _broadcast_at_updates(state) -> list[dict]:
+    """Filter `metadata_updates` down to just the broadcast_at writes."""
+    return [u for u in state["metadata_updates"] if "broadcast_at" in u["partial"]]
+
+
+# ---------------------------------------------------------------------------
+# Post-draft
+# ---------------------------------------------------------------------------
+
+
+class TestPostdraftStamp:
+    def test_stamps_on_broadcast_success(self, patched_postdraft) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        run(dry_run=False, force=True)
+        stamps = _broadcast_at_updates(patched_postdraft)
+        assert len(stamps) == 1
+        assert stamps[0]["partial"]["broadcast_at"]
+        # Stamp goes to the right key.
+        assert stamps[0]["report_type"] == "postDraft"
+
+    def test_no_stamp_on_dry_run(self, patched_postdraft) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        run(dry_run=True, force=False)
+        assert _broadcast_at_updates(patched_postdraft) == []
+
+    def test_no_stamp_on_ses_failure(
+        self, patched_postdraft, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger import orchestrator
+
+        def _raise(tasks):
+            raise RuntimeError("SES is on fire")
+
+        monkeypatch.setattr(orchestrator, "send_emails_concurrently", _raise)
+
+        with pytest.raises(RuntimeError):
+            orchestrator.run(dry_run=False, force=True)
+
+        # No broadcast_at stamp was written because the SES call raised
+        # before the stamp helper would run.
+        assert _broadcast_at_updates(patched_postdraft) == []
+
+
+# ---------------------------------------------------------------------------
+# Preseason
+# ---------------------------------------------------------------------------
+
+
+class TestPreseasonStamp:
+    def test_stamps_on_broadcast_success(self, patched_preseason) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        run(dry_run=False, force=True)
+        stamps = _broadcast_at_updates(patched_preseason)
+        assert len(stamps) == 1
+        assert stamps[0]["partial"]["broadcast_at"]
+        assert stamps[0]["report_type"] == "preseason"
+
+    def test_no_stamp_on_dry_run(self, patched_preseason) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        run(dry_run=True, force=False)
+        assert _broadcast_at_updates(patched_preseason) == []
+
+    def test_no_stamp_on_ses_failure(
+        self, patched_preseason, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger import orchestrator
+
+        def _raise(tasks):
+            raise RuntimeError("SES is on fire")
+
+        monkeypatch.setattr(orchestrator, "send_emails_concurrently", _raise)
+
+        with pytest.raises(RuntimeError):
+            orchestrator.run(dry_run=False, force=True)
+
+        assert _broadcast_at_updates(patched_preseason) == []
+
+
+# ---------------------------------------------------------------------------
+# Weekly
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyStamp:
+    def test_stamps_on_broadcast_success(self, patched_weekly) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(dry_run=False, force=True)
+        stamps = _broadcast_at_updates(patched_weekly)
+        assert len(stamps) == 1
+        assert stamps[0]["partial"]["broadcast_at"]
+        assert stamps[0]["report_type"] == "weekly"
+
+    def test_no_stamp_on_dry_run(self, patched_weekly) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(dry_run=True, force=False)
+        assert _broadcast_at_updates(patched_weekly) == []
+
+    def test_no_stamp_on_ses_failure(
+        self, patched_weekly, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.common import weekly_orchestrator
+
+        def _raise(tasks):
+            raise RuntimeError("SES is on fire")
+
+        monkeypatch.setattr(weekly_orchestrator, "send_emails_concurrently", _raise)
+
+        with pytest.raises(RuntimeError):
+            weekly_orchestrator.run_weekly(dry_run=False, force=True)
+
+        assert _broadcast_at_updates(patched_weekly) == []

--- a/tests/test_orchestrator_dnb_abort.py
+++ b/tests/test_orchestrator_dnb_abort.py
@@ -1,0 +1,171 @@
+"""
+Cross-orchestrator DNB-abort tests (admin-portal F3).
+
+Asserts that all three broadcast orchestrators (post-draft, preseason,
+weekly) re-read the report's metadata immediately before SES fan-out
+and abort with `DoNotBroadcastError` (HTTP 409) when
+`metadata.do_not_broadcast == "true"`.
+
+Also covers the inverse: the dry-run path is unaffected, and the
+normal broadcast path runs end-to-end when the flag is absent.
+
+Re-uses the existing test fixtures via pytest's fixture system so we
+don't rebuild the entire patched-orchestrator surface. Each fixture
+sets a `fresh_metadata` override on its `state` dict that the
+fixture's `_get_report` stub uses to inject the DNB flag on the
+post-write re-read.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Re-export the existing fixtures so this module's tests can reuse them.
+from tests.test_api_admin_ai_review_postdraft_trigger import (  # noqa: F401
+    patched_orchestrator as patched_postdraft,
+)
+from tests.test_api_admin_ai_review_preseason_trigger import (  # noqa: F401
+    patched_orchestrator as patched_preseason,
+)
+from tests.test_api_admin_ai_review_weekly_trigger import (  # noqa: F401
+    patched_orchestrator as patched_weekly,
+)
+
+
+# ---------------------------------------------------------------------------
+# Post-draft
+# ---------------------------------------------------------------------------
+
+
+class TestPostdraftDNB:
+    def test_dnb_aborts_broadcast(self, patched_postdraft) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+        from lambdas.common.errors import DoNotBroadcastError
+
+        # Override the post-write re-read to surface do_not_broadcast=true.
+        patched_postdraft["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        with pytest.raises(DoNotBroadcastError):
+            run(dry_run=False, force=False)
+
+        # SES fan-out never ran.
+        assert patched_postdraft["emails_sent"] == []
+        assert patched_postdraft["pushes_sent"] == []
+        # broadcast_at was NEVER stamped because abort happened first.
+        assert all(
+            "broadcast_at" not in u["partial"]
+            for u in patched_postdraft["metadata_updates"]
+        )
+
+    def test_dnb_does_not_abort_dry_run(self, patched_postdraft) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        patched_postdraft["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        # Dry-run path skips the DNB check entirely.
+        result = run(dry_run=True, force=False)
+        assert result["status"] == "dry_run_sent"
+        # Admin still gets the dry-run email.
+        assert len(patched_postdraft["emails_sent"]) == 1
+
+    def test_no_dnb_flag_runs_broadcast_normally(self, patched_postdraft) -> None:
+        from lambdas.api_admin_ai_review_postdraft_trigger.orchestrator import run
+
+        # No fresh_metadata override -> get_report returns the write
+        # as-is (no do_not_broadcast key).
+        result = run(dry_run=False, force=True)
+
+        assert result["status"] == "broadcast"
+        assert result["delivery_count"] == 12
+        # broadcast_at was stamped.
+        assert any(
+            "broadcast_at" in u["partial"]
+            for u in patched_postdraft["metadata_updates"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Preseason
+# ---------------------------------------------------------------------------
+
+
+class TestPreseasonDNB:
+    def test_dnb_aborts_broadcast(self, patched_preseason) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+        from lambdas.common.errors import DoNotBroadcastError
+
+        patched_preseason["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        with pytest.raises(DoNotBroadcastError):
+            run(dry_run=False, force=False)
+
+        assert patched_preseason["emails_sent"] == []
+        assert patched_preseason["pushes_sent"] == []
+        assert all(
+            "broadcast_at" not in u["partial"]
+            for u in patched_preseason["metadata_updates"]
+        )
+
+    def test_dnb_does_not_abort_dry_run(self, patched_preseason) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        patched_preseason["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        result = run(dry_run=True, force=False)
+        assert result["status"] == "dry_run_sent"
+        assert len(patched_preseason["emails_sent"]) == 1
+
+    def test_no_dnb_flag_runs_broadcast_normally(self, patched_preseason) -> None:
+        from lambdas.api_admin_ai_review_preseason_trigger.orchestrator import run
+
+        result = run(dry_run=False, force=True)
+        assert result["status"] == "broadcast"
+        assert result["delivery_count"] == 12
+        assert any(
+            "broadcast_at" in u["partial"]
+            for u in patched_preseason["metadata_updates"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Weekly
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyDNB:
+    def test_dnb_aborts_broadcast(self, patched_weekly) -> None:
+        from lambdas.common.errors import DoNotBroadcastError
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_weekly["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        with pytest.raises(DoNotBroadcastError):
+            run_weekly(dry_run=False, force=False)
+
+        assert patched_weekly["emails_sent"] == []
+        assert patched_weekly["pushes_sent"] == []
+        # Memory_count_out update can happen pre-DNB-check, but the
+        # broadcast_at stamp must not.
+        assert all(
+            "broadcast_at" not in u["partial"]
+            for u in patched_weekly["metadata_updates"]
+        )
+
+    def test_dnb_does_not_abort_dry_run(self, patched_weekly) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_weekly["fresh_metadata"] = {"do_not_broadcast": "true"}
+
+        result = run_weekly(dry_run=True, force=False)
+        assert result["status"] == "dry_run_sent"
+        assert len(patched_weekly["emails_sent"]) == 1
+
+    def test_no_dnb_flag_runs_broadcast_normally(self, patched_weekly) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        result = run_weekly(dry_run=False, force=True)
+        assert result["status"] == "broadcast"
+        assert result["delivery_count"] == 12
+        assert any(
+            "broadcast_at" in u["partial"]
+            for u in patched_weekly["metadata_updates"]
+        )


### PR DESCRIPTION
## Summary

Closes the F3 broadcast-safety loop in three coordinated pieces:

- **New POST `/admin/reports-flag` endpoint** (`api_admin_reports_flag`) toggles `metadata.is_redacted` / `metadata.do_not_broadcast` on any AI report row. Admin-gated; validates flag name + bool value; returns the full updated metadata dict so iOS can refresh in place. `TODO(F4)` audit-log markers at every mutation point.
- **`DoNotBroadcastError` (409)** raised by all three orchestrators (postdraft, preseason, weekly) when `metadata.do_not_broadcast == "true"` is observed on a post-write re-read immediately before SES fan-out. Dry-run path unaffected. Catches the race where an admin flips DNB on between generation and broadcast.
- **Canonical `ai_reports_store.stamp_broadcast_at(...)` helper** replaces the inline `update_metadata({broadcast_at: ...})` in postdraft and adds the same stamp to preseason + weekly. Stamps AFTER `send_emails_concurrently` returns success so partial fan-out failures don't leave the report marked broadcast.
- **Read-path redact filter** via new non-raising `admin_gate.is_admin(event) -> bool`. `api_ai_reports_latest` returns null for redacted rows when caller isn't admin (matches the iOS empty-state path — no info leak). `api_ai_reports_list` filters redacted rows out for non-admin callers.

## Depends on

- Infra PR #109 — path-flattened `/admin/reports-flag` route.

## References

- Epic plan: `docs/features/admin-portal/EPIC_PLAN.md`
- F3 plan: `docs/features/admin-portal/f3-redact/PLAN.md` (xomper-ios)
- Epic issue: #91

## Test plan

- [x] `pytest tests/` — 371 pass (327 baseline + 44 new)
- [x] New tests: `test_api_admin_reports_flag.py`, `test_admin_gate_is_admin.py`, `test_orchestrator_dnb_abort.py`, `test_orchestrator_broadcast_at_stamp.py`, `test_api_ai_reports_redact_filter.py`, plus `test_ai_reports_store::TestStampBroadcastAt`
- [x] Existing orchestrator fixtures updated to wire `get_report` (DNB re-read) + `stamp_broadcast_at` (helper routing)
- [ ] Manual smoke (post-merge + deploy): `curl POST /admin/reports-flag` with a known admin JWT + report; verify metadata in Dynamo
- [ ] Manual smoke: dry-run a report, toggle DNB on, retry broadcast → 409 with `do_not_broadcast` error code
- [ ] Manual smoke: redact a sent report, hit `/ai-reports/latest` as non-admin → null; as admin → row visible