### PR TITLE
feat(admin-portal F5): backend — CloudWatch logs query + PII redaction

### DIFF
--- a/lambdas/api_admin_logs_query/handler.py
+++ b/lambdas/api_admin_logs_query/handler.py
@@ -1,0 +1,335 @@
+"""
+GET /admin/logs-query
+=====================
+Admin-only CloudWatch log tail (admin-portal F5). Wraps
+``boto3.client('logs').filter_log_events(...)`` against a hard-coded
+allowlist of 10 lambda log groups (every admin / AI-review / notif
+lambda touched by the admin-portal epic), redacts PII server-side
+before returning, caches identical first-page queries for 60 seconds
+to dampen rapid polling, and paginates via ``next_token``.
+
+Query params:
+- ``log_group``   (required)  — slug key from ``ADMIN_LOG_GROUP_ALLOWLIST``.
+                                 Validated against the allowlist; unknown
+                                 slugs yield a 400. The lambda's IAM
+                                 role also enforces this (only the 10
+                                 allowlisted ARNs are reachable), so
+                                 this validation is defense in depth.
+- ``level``       (optional)  — one of ``info`` / ``warn`` / ``error``.
+                                 Applied as a post-fetch filter on the
+                                 heuristically-derived per-event level.
+- ``search``      (optional)  — literal substring; passed through to
+                                 CloudWatch ``filterPattern`` as a
+                                 quoted string. No regex.
+- ``limit``       (optional)  — 1-200, default 50. Out-of-range values
+                                 are clamped to the nearest bound;
+                                 unparseable values fall back to 50.
+- ``next_token``  (optional)  — opaque CloudWatch cursor. When present,
+                                 the module-level cache is bypassed
+                                 (paginated calls always re-fetch).
+
+Response:
+    {
+      "Success":    true,
+      "log_group":  "ai-review-weekly",
+      "events": [
+        {
+          "id":        "<eventId>",
+          "timestamp": "<ISO-8601 UTC>",
+          "level":     "ERROR" | "WARN" | "INFO" | null,
+          "message":   "<redacted>"
+        },
+        ...
+      ],
+      "next_token": "<cursor>" | null
+    }
+
+Errors:
+- 403 — caller is not admin.
+- 400 — ``log_group`` missing or not in the allowlist.
+
+Cache:
+- Module-level dict, 60s TTL, keyed by
+  ``(log_group, level, search, limit)``. ``next_token`` is excluded
+  from the key so paginating doesn't blow up the cache. Cold starts
+  naturally evict.
+"""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import boto3
+
+from lambdas.common.admin_gate import NotAdmin, require_admin
+from lambdas.common.constants import ADMIN_LOG_GROUP_ALLOWLIST, AWS_DEFAULT_REGION
+from lambdas.common.errors import handle_errors
+from lambdas.common.log_redact import redact
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import get_query_params, success_response
+
+log = get_logger(__file__)
+HANDLER = "api_admin_logs_query"
+
+DEFAULT_LIMIT = 50
+MAX_LIMIT = 200
+MIN_LIMIT = 1
+CACHE_TTL_SECONDS = 60
+
+ALLOWED_LEVELS = {"info", "warn", "error"}
+
+# Module-level cache. Keyed by ``(log_group, level, search, limit)``
+# (next_token deliberately excluded). Value is ``(inserted_at, body)``.
+# Cleared on cold start; per-warm-container only.
+_CACHE: dict[tuple[str, Optional[str], Optional[str], int], tuple[float, dict[str, Any]]] = {}
+
+# Lazily-initialised CloudWatch Logs client. Module-level so warm
+# containers reuse the connection pool.
+_LOGS_CLIENT: Any = None
+
+
+def _logs_client() -> Any:
+    """Lazy boto3 client init so unit tests can monkeypatch the
+    module attribute before the first handler call."""
+    global _LOGS_CLIENT
+    if _LOGS_CLIENT is None:
+        _LOGS_CLIENT = boto3.client("logs", region_name=AWS_DEFAULT_REGION)
+    return _LOGS_CLIENT
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    log.info("Admin logs-query request")
+
+    try:
+        require_admin(event)
+    except NotAdmin:
+        return success_response(
+            {"Success": False, "Message": "Not authorized"},
+            status_code=403,
+        )
+
+    qs = get_query_params(event)
+
+    log_group_slug = (qs.get("log_group") or "").strip()
+    if not log_group_slug:
+        return success_response(
+            {
+                "Success": False,
+                "Message": "log_group is required",
+                "allowed": sorted(ADMIN_LOG_GROUP_ALLOWLIST.keys()),
+            },
+            status_code=400,
+        )
+    if log_group_slug not in ADMIN_LOG_GROUP_ALLOWLIST:
+        log.warning(
+            f"logs-query: rejecting non-allowlisted log_group='{log_group_slug}'"
+        )
+        return success_response(
+            {
+                "Success": False,
+                "Message": (
+                    f"log_group '{log_group_slug}' is not allowlisted. "
+                    "Defense in depth: IAM also denies."
+                ),
+                "allowed": sorted(ADMIN_LOG_GROUP_ALLOWLIST.keys()),
+            },
+            status_code=400,
+        )
+
+    level = _parse_level(qs.get("level"))
+    search = (qs.get("search") or "").strip() or None
+    limit = _parse_limit(qs.get("limit"))
+    next_token = (qs.get("next_token") or "").strip() or None
+
+    # Cache check. Pagination (``next_token`` set) bypasses entirely
+    # so "Load older" never returns the cached first page.
+    cache_key: tuple[str, Optional[str], Optional[str], int] = (
+        log_group_slug,
+        level,
+        search,
+        limit,
+    )
+    if next_token is None:
+        cached = _cache_get(cache_key)
+        if cached is not None:
+            log.info(f"logs-query: cache hit for {cache_key}")
+            return success_response(cached)
+
+    log_group_name = ADMIN_LOG_GROUP_ALLOWLIST[log_group_slug]
+    boto_kwargs: dict[str, Any] = {
+        "logGroupName": log_group_name,
+        "limit": limit,
+    }
+    filter_pattern = _build_filter_pattern(search)
+    if filter_pattern:
+        boto_kwargs["filterPattern"] = filter_pattern
+    if next_token is not None:
+        boto_kwargs["nextToken"] = next_token
+
+    log.info(
+        f"logs-query: calling filter_log_events log_group='{log_group_slug}' "
+        f"limit={limit} level={level} has_search={search is not None} "
+        f"has_token={next_token is not None}"
+    )
+
+    response = _logs_client().filter_log_events(**boto_kwargs)
+    raw_events = response.get("events") or []
+    cw_next_token = response.get("nextToken")
+
+    events: list[dict[str, Any]] = []
+    for raw in raw_events:
+        ev = _format_event(raw)
+        # Post-fetch level filter — CloudWatch's filterPattern can't
+        # see our heuristic, so we apply the cut here.
+        if level is not None and (ev["level"] or "").lower() != level:
+            continue
+        events.append(ev)
+
+    body = {
+        "Success": True,
+        "log_group": log_group_slug,
+        "events": events,
+        "next_token": cw_next_token,
+    }
+
+    # Only cache first-page results. Paginated calls (next_token set)
+    # are inherently transient cursors — caching them would just bloat
+    # the dict for no real hit rate.
+    if next_token is None:
+        _cache_put(cache_key, body)
+
+    return success_response(body)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_level(raw: Any) -> Optional[str]:
+    """Normalise level to one of ``info`` / ``warn`` / ``error``.
+    Unknown / empty values return None (no filter applied)."""
+    if not raw:
+        return None
+    value = str(raw).strip().lower()
+    if value == "warning":
+        value = "warn"
+    if value not in ALLOWED_LEVELS:
+        return None
+    return value
+
+
+def _parse_limit(raw: Any) -> int:
+    """Parse the ``limit`` query param. Defaults to ``DEFAULT_LIMIT``;
+    clamps to ``[MIN_LIMIT, MAX_LIMIT]``. Unparseable falls back to
+    the default."""
+    if raw is None or raw == "":
+        return DEFAULT_LIMIT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+    if value < MIN_LIMIT:
+        return MIN_LIMIT
+    if value > MAX_LIMIT:
+        return MAX_LIMIT
+    return value
+
+
+def _build_filter_pattern(search: Optional[str]) -> Optional[str]:
+    """Build a CloudWatch ``filterPattern`` from the search string.
+
+    CloudWatch quoted-string filters do literal substring matching,
+    which is what F5 ships (regex was rejected as out-of-scope). We
+    return None when there's nothing to filter on so boto3 omits the
+    parameter and CloudWatch returns the raw tail.
+    """
+    if not search:
+        return None
+    # Escape embedded double quotes so the search string can't break
+    # out of the quoted filter pattern.
+    sanitized = search.replace('"', '\\"')
+    return f'"{sanitized}"'
+
+
+def _detect_level(message: str) -> Optional[str]:
+    """Best-effort substring scan over the event message.
+
+    Looks for ``ERROR`` / ``WARN`` / ``WARNING`` / ``INFO`` markers in
+    typical Python / xomper log formats. Returns the uppercase level
+    string (so callers can lowercase if needed) or None when no
+    marker is present.
+
+    Documented as best-effort — the heuristic only annotates rows for
+    the UI chip; it does NOT gate what's returned (the optional
+    ``level`` query param applies the cut on top of this).
+    """
+    if not isinstance(message, str) or not message:
+        return None
+    # Order matters: WARNING contains WARN as a substring; ERROR is
+    # checked first so a stray "WARNING about ERROR" still resolves
+    # to ERROR (the more severe).
+    if "ERROR" in message:
+        return "ERROR"
+    if "WARNING" in message or "WARN" in message:
+        return "WARN"
+    if "INFO" in message:
+        return "INFO"
+    return None
+
+
+def _format_event(raw: dict[str, Any]) -> dict[str, Any]:
+    """Project a CloudWatch ``filter_log_events`` event onto the wire
+    shape. Applies PII redaction to ``message`` and ISO-8601 formats
+    the millisecond-epoch timestamp."""
+    message = raw.get("message") or ""
+    redacted = redact(message)
+    level = _detect_level(message)
+
+    ts_ms = raw.get("timestamp")
+    if isinstance(ts_ms, (int, float)) and ts_ms > 0:
+        try:
+            iso = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc).isoformat()
+        except (OverflowError, OSError, ValueError):
+            iso = None
+    else:
+        iso = None
+
+    return {
+        "id": raw.get("eventId"),
+        "timestamp": iso,
+        "level": level,
+        "message": redacted,
+    }
+
+
+def _cache_get(
+    key: tuple[str, Optional[str], Optional[str], int],
+) -> Optional[dict[str, Any]]:
+    """Return the cached body for ``key`` if still fresh, else None.
+    Stale entries are evicted on read to keep the dict bounded."""
+    entry = _CACHE.get(key)
+    if entry is None:
+        return None
+    inserted_at, body = entry
+    if (time.time() - inserted_at) > CACHE_TTL_SECONDS:
+        _CACHE.pop(key, None)
+        return None
+    return body
+
+
+def _cache_put(
+    key: tuple[str, Optional[str], Optional[str], int],
+    body: dict[str, Any],
+) -> None:
+    """Stamp ``body`` into the cache for ``key`` at the current
+    wall-clock time."""
+    _CACHE[key] = (time.time(), body)
+
+
+def _cache_clear() -> None:
+    """Test hook — clears the module-level cache. Tests that exercise
+    cache hit/miss must call this in setup to isolate runs."""
+    _CACHE.clear()

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -58,3 +58,23 @@ ADMIN_DOMINICK_USER_ID = "594625531702460416"
 # LOGO URL
 LOGO_URL = f"{XOMPER_URL}/assets/img/xomper-logo.jpg"
 BANNER_LOGO_URL = f"{XOMPER_URL}/assets/img/xomper-banner.jpg"
+
+# Admin Portal F5 — CloudWatch Log Viewer.
+# Allowlist of log groups the admin CloudWatch tail can read. The key
+# is the API-facing slug (what iOS sends + what the IAM policy uses as
+# a label); the value is the full CloudWatch log group name. The
+# `api_admin_logs_query` lambda validates the inbound `log_group`
+# param against these keys as defense-in-depth — the lambda's IAM
+# role is also scoped to exactly these 10 ARNs by Terraform.
+ADMIN_LOG_GROUP_ALLOWLIST = {
+    "ai-review-postdraft": "/aws/lambda/xomper-api-admin-ai-review-postdraft-trigger",
+    "ai-review-preseason": "/aws/lambda/xomper-api-admin-ai-review-preseason-trigger",
+    "ai-review-weekly": "/aws/lambda/xomper-api-admin-ai-review-weekly-trigger",
+    "ai-review-weekly-cron": "/aws/lambda/xomper-notif-ai-review-weekly",
+    "weekly-recap": "/aws/lambda/xomper-notif-weekly-recap",
+    "email-test": "/aws/lambda/xomper-api-admin-email-test",
+    "reports-flag": "/aws/lambda/xomper-api-admin-reports-flag",
+    "users-update": "/aws/lambda/xomper-api-admin-users-update",
+    "leagues-update": "/aws/lambda/xomper-api-admin-leagues-update",
+    "audit-list": "/aws/lambda/xomper-api-admin-audit-list",
+}

--- a/lambdas/common/log_redact.py
+++ b/lambdas/common/log_redact.py
@@ -1,0 +1,51 @@
+"""
+PII redaction for the admin CloudWatch log tail (F5)
+====================================================
+Best-effort regex sweep applied to every log event message before it
+leaves the backend. The redactions are:
+
+- Email addresses → ``***@***``
+- Sleeper user IDs (long numeric, 15-20 digits) → ``[uid]``
+- Anthropic API keys (``sk-ant-...``) → ``[key]``
+
+These three patterns cover every known leak shape in xomper logs. A
+generic "JSON field ending in `_key`/`_token`" sweep was rejected in
+the F5 BRAINSTORM — too noisy in trace dumps.
+
+The helper is intentionally tiny + side-effect-free so it stays
+straightforward to unit-test (`tests/test_log_redact.py` locks the
+contract).
+"""
+from __future__ import annotations
+
+import re
+
+# Email — local part + `@` + domain. Permissive on the local part so we
+# catch `foo.bar+tag@example.com`. The TLD is required (`\w+` after the
+# final dot) to avoid matching short numeric runs like `1@2`.
+EMAIL_RE = re.compile(r"[\w.+-]+@[\w.-]+\.\w+")
+
+# Sleeper user IDs are 18-19 digits today. We accept 15-20 to be safe
+# against historical short / future long IDs. Word boundaries on both
+# sides so we don't chew through a 30-digit blob.
+SLEEPER_ID_RE = re.compile(r"\b\d{15,20}\b")
+
+# Anthropic API keys are prefixed `sk-ant-` and contain word chars +
+# hyphens. The 20+ tail length keeps us from matching short
+# placeholders like `sk-ant-test`.
+ANTHROPIC_KEY_RE = re.compile(r"sk-ant-[\w-]{20,}")
+
+
+def redact(text: str) -> str:
+    """Apply all PII redactions to ``text``. Best-effort; doesn't raise.
+
+    Non-string input (None, ints, dicts that snuck through) returns the
+    empty string so the handler can always emit a stringy message
+    field without TypeError noise.
+    """
+    if not isinstance(text, str):
+        return ""
+    text = EMAIL_RE.sub("***@***", text)
+    text = SLEEPER_ID_RE.sub("[uid]", text)
+    text = ANTHROPIC_KEY_RE.sub("[key]", text)
+    return text

--- a/tests/test_api_admin_logs_query.py
+++ b/tests/test_api_admin_logs_query.py
@@ -1,0 +1,577 @@
+"""
+Tests for ``api_admin_logs_query`` (admin-portal F5).
+
+Endpoint shape: GET /admin/logs-query
+    ?log_group=&level=&search=&limit=&next_token=
+
+Covers:
+- 403 when caller is not admin.
+- 400 when ``log_group`` is missing.
+- 400 when ``log_group`` is not in ``ADMIN_LOG_GROUP_ALLOWLIST``
+  (defense-in-depth; IAM also enforces).
+- Happy path: mocked boto3 ``filter_log_events`` returns events;
+  handler redacts PII in the returned ``message`` field; response
+  shape matches the wire contract.
+- ``search`` query param is wrapped in a quoted ``filterPattern`` and
+  passed through to boto3.
+- ``level`` filter is applied AFTER fetch via the heuristic substring
+  scan — only matching events are returned.
+- Cache hit: two identical first-page calls within 60s → boto3 is
+  called once.
+- Cache miss after TTL: a synthetic time jump past 60s → boto3 is
+  called again.
+- ``next_token`` bypasses the cache entirely.
+- ``limit`` parsing: > 200 clamps to 200, < 1 clamps to 1,
+  unparseable falls back to the default 50.
+- Heuristic level detection: messages containing ``ERROR`` /
+  ``WARN`` / ``INFO`` substrings get the expected level tag.
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _api_event(
+    *,
+    qs: dict[str, Any] | None = None,
+    sleeper_user_id: str | None = ADMIN_ID,
+) -> dict[str, Any]:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "GET",
+        "path": "/admin/logs-query",
+        "headers": headers,
+        "queryStringParameters": qs or {},
+    }
+
+
+def _cw_event(
+    *,
+    event_id: str,
+    timestamp_ms: int,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "eventId": event_id,
+        "timestamp": timestamp_ms,
+        "message": message,
+    }
+
+
+@pytest.fixture
+def patched_handler(monkeypatch: pytest.MonkeyPatch):
+    """Stubs the admin gate to a fixed admin row, replaces the boto3
+    CloudWatch Logs client with an in-memory stub, and clears the
+    module-level cache to isolate runs."""
+    from lambdas.api_admin_logs_query import handler as h
+
+    h._cache_clear()
+
+    state: dict[str, Any] = {
+        "admin_row": {
+            "id": "row-admin",
+            "sleeper_user_id": ADMIN_ID,
+            "is_admin": True,
+            "is_active": True,
+        },
+        # The script of what boto3 returns. The fixture sets a default;
+        # individual tests override it.
+        "cw_response": {
+            "events": [
+                _cw_event(
+                    event_id="e1",
+                    timestamp_ms=1748340000000,  # 2025-05-27T...
+                    message="INFO Starting weekly recap for league xyz.",
+                ),
+                _cw_event(
+                    event_id="e2",
+                    timestamp_ms=1748340060000,
+                    message=(
+                        "ERROR failed for user@example.com "
+                        "(id 594625531702460416)"
+                    ),
+                ),
+            ],
+            "nextToken": None,
+        },
+        "boto_calls": [],
+        # Monkey-patched time source for cache TTL tests.
+        "now": time.time(),
+    }
+
+    class _LogsClientStub:
+        def filter_log_events(self, **kwargs: Any) -> dict[str, Any]:
+            state["boto_calls"].append(kwargs)
+            return state["cw_response"]
+
+    def _require_admin(event: dict[str, Any], body: Any = None) -> dict[str, Any]:
+        return state["admin_row"]
+
+    monkeypatch.setattr(h, "require_admin", _require_admin)
+    # Inject the stub by overriding the lazy boto3 client accessor.
+    monkeypatch.setattr(h, "_LOGS_CLIENT", _LogsClientStub())
+    # Time control for cache tests.
+    monkeypatch.setattr(h.time, "time", lambda: state["now"])
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestAdminGate:
+    def test_non_admin_returns_403(
+        self, patched_handler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+        from lambdas.common.admin_gate import NotAdmin
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body=None: (_ for _ in ()).throw(NotAdmin("nope")),
+        )
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}),
+            context=None,
+        )
+        assert response["statusCode"] == 403
+        assert patched_handler["boto_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlist validation (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlistValidation:
+    def test_missing_log_group_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        response = h.handler(_api_event(qs={}), context=None)
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "log_group" in parsed["Message"].lower()
+        assert "allowed" in parsed
+        assert "ai-review-weekly" in parsed["allowed"]
+        assert patched_handler["boto_calls"] == []
+
+    def test_unknown_log_group_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        response = h.handler(
+            _api_event(qs={"log_group": "not-a-real-group"}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        parsed = json.loads(response["body"])
+        assert parsed["Success"] is False
+        assert "not allowlisted" in parsed["Message"]
+        assert patched_handler["boto_calls"] == []
+
+    def test_all_10_allowlisted_keys_pass(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+        from lambdas.common.constants import ADMIN_LOG_GROUP_ALLOWLIST
+
+        # Sanity: the allowlist hasn't drifted from 10.
+        assert len(ADMIN_LOG_GROUP_ALLOWLIST) == 10
+
+        for slug in ADMIN_LOG_GROUP_ALLOWLIST:
+            h._cache_clear()
+            response = h.handler(
+                _api_event(qs={"log_group": slug}),
+                context=None,
+            )
+            assert response["statusCode"] == 200, slug
+
+
+# ---------------------------------------------------------------------------
+# Happy path + wire contract + redaction
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_returns_redacted_events_with_iso_timestamp_and_level(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        parsed = json.loads(response["body"])
+
+        assert parsed["Success"] is True
+        assert parsed["log_group"] == "ai-review-weekly"
+        assert parsed["next_token"] is None
+        assert len(parsed["events"]) == 2
+
+        # Wire contract.
+        first = parsed["events"][0]
+        assert set(first.keys()) == {"id", "timestamp", "level", "message"}
+        assert first["id"] == "e1"
+        assert first["timestamp"].startswith("20")  # ISO-8601
+        assert first["level"] == "INFO"
+        assert first["message"].startswith("INFO Starting")
+
+        # Redaction applied to the second event.
+        second = parsed["events"][1]
+        assert second["level"] == "ERROR"
+        assert "user@example.com" not in second["message"]
+        assert "594625531702460416" not in second["message"]
+        assert "***@***" in second["message"]
+        assert "[uid]" in second["message"]
+
+    def test_boto_called_with_resolved_log_group_name(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(_api_event(qs={"log_group": "weekly-recap"}), context=None)
+        call = patched_handler["boto_calls"][0]
+        assert call["logGroupName"] == "/aws/lambda/xomper-notif-weekly-recap"
+        assert call["limit"] == 50
+        # No search → no filterPattern.
+        assert "filterPattern" not in call
+        # No pagination → no nextToken.
+        assert "nextToken" not in call
+
+
+# ---------------------------------------------------------------------------
+# Search + level filters
+# ---------------------------------------------------------------------------
+
+
+class TestSearchFilter:
+    def test_search_passes_through_as_quoted_filter_pattern(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "search": "draft"}),
+            context=None,
+        )
+        call = patched_handler["boto_calls"][0]
+        assert call["filterPattern"] == '"draft"'
+
+    def test_search_with_embedded_quote_is_escaped(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "search": 'foo "bar" baz'}
+            ),
+            context=None,
+        )
+        call = patched_handler["boto_calls"][0]
+        assert call["filterPattern"] == '"foo \\"bar\\" baz"'
+
+
+class TestLevelFilter:
+    def test_level_error_excludes_info_events(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        response = h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "level": "error"}
+            ),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        # Only the ERROR event survives the post-fetch cut.
+        assert len(parsed["events"]) == 1
+        assert parsed["events"][0]["level"] == "ERROR"
+
+    def test_level_warning_alias_normalises_to_warn(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        patched_handler["cw_response"] = {
+            "events": [
+                _cw_event(
+                    event_id="w1",
+                    timestamp_ms=1748340000000,
+                    message="WARNING something fishy",
+                ),
+                _cw_event(
+                    event_id="i1",
+                    timestamp_ms=1748340000001,
+                    message="INFO normal flow",
+                ),
+            ],
+            "nextToken": None,
+        }
+
+        response = h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "level": "warning"}
+            ),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        assert len(parsed["events"]) == 1
+        assert parsed["events"][0]["id"] == "w1"
+        assert parsed["events"][0]["level"] == "WARN"
+
+    def test_invalid_level_value_is_silently_ignored(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        response = h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "level": "fatal"}
+            ),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        # Both events come back — invalid level means "no filter".
+        assert len(parsed["events"]) == 2
+
+
+class TestLevelDetectionHeuristic:
+    def test_error_substring(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        patched_handler["cw_response"] = {
+            "events": [
+                _cw_event(
+                    event_id="e1",
+                    timestamp_ms=1748340000000,
+                    message="[ERROR] something blew up",
+                )
+            ],
+            "nextToken": None,
+        }
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        assert parsed["events"][0]["level"] == "ERROR"
+
+    def test_warn_and_warning_both_detected(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        patched_handler["cw_response"] = {
+            "events": [
+                _cw_event(
+                    event_id="w1",
+                    timestamp_ms=1748340000000,
+                    message="WARNING about a thing",
+                ),
+                _cw_event(
+                    event_id="w2",
+                    timestamp_ms=1748340000001,
+                    message="[WARN] another thing",
+                ),
+            ],
+            "nextToken": None,
+        }
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        assert parsed["events"][0]["level"] == "WARN"
+        assert parsed["events"][1]["level"] == "WARN"
+
+    def test_unknown_level_returns_null(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        patched_handler["cw_response"] = {
+            "events": [
+                _cw_event(
+                    event_id="u1",
+                    timestamp_ms=1748340000000,
+                    message="just some text without any level marker",
+                )
+            ],
+            "nextToken": None,
+        }
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}),
+            context=None,
+        )
+        parsed = json.loads(response["body"])
+        assert parsed["events"][0]["level"] is None
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    def test_two_identical_calls_within_ttl_hit_boto_once(
+        self, patched_handler
+    ) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        # Advance time within the TTL window.
+        patched_handler["now"] += 30
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+
+        assert len(patched_handler["boto_calls"]) == 1
+
+    def test_call_after_ttl_refetches(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        # Past TTL.
+        patched_handler["now"] += 61
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+
+        assert len(patched_handler["boto_calls"]) == 2
+
+    def test_different_keys_cache_independently(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        h.handler(
+            _api_event(qs={"log_group": "weekly-recap"}), context=None
+        )
+
+        assert len(patched_handler["boto_calls"]) == 2
+
+    def test_next_token_bypasses_cache(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        # Prime first page in cache.
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        assert len(patched_handler["boto_calls"]) == 1
+
+        # Paginated call (same keys EXCEPT next_token) must go to boto3
+        # every time, even though the cache key (log_group, level,
+        # search, limit) is identical.
+        h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "next_token": "abc"}
+            ),
+            context=None,
+        )
+        h.handler(
+            _api_event(
+                qs={"log_group": "ai-review-weekly", "next_token": "def"}
+            ),
+            context=None,
+        )
+        assert len(patched_handler["boto_calls"]) == 3
+        # The paginated calls included nextToken in the boto args.
+        assert patched_handler["boto_calls"][1]["nextToken"] == "abc"
+        assert patched_handler["boto_calls"][2]["nextToken"] == "def"
+
+    def test_search_variant_does_not_share_cache(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "search": "x"}),
+            context=None,
+        )
+        assert len(patched_handler["boto_calls"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Limit bounds
+# ---------------------------------------------------------------------------
+
+
+class TestLimitBounds:
+    def test_limit_above_max_clamps_to_200(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "limit": "500"}),
+            context=None,
+        )
+        assert patched_handler["boto_calls"][0]["limit"] == 200
+
+    def test_limit_below_min_clamps_to_1(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "limit": "0"}),
+            context=None,
+        )
+        assert patched_handler["boto_calls"][0]["limit"] == 1
+
+    def test_invalid_limit_falls_back_to_default(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "limit": "abc"}),
+            context=None,
+        )
+        assert patched_handler["boto_calls"][0]["limit"] == 50
+
+    def test_limit_at_max_passes_through(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly", "limit": "200"}),
+            context=None,
+        )
+        assert patched_handler["boto_calls"][0]["limit"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Pagination passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    def test_next_token_in_response_is_surfaced(self, patched_handler) -> None:
+        from lambdas.api_admin_logs_query import handler as h
+
+        patched_handler["cw_response"] = {
+            "events": [
+                _cw_event(
+                    event_id="p1",
+                    timestamp_ms=1748340000000,
+                    message="INFO page 1",
+                )
+            ],
+            "nextToken": "cursor-abc",
+        }
+
+        response = h.handler(
+            _api_event(qs={"log_group": "ai-review-weekly"}), context=None
+        )
+        parsed = json.loads(response["body"])
+        assert parsed["next_token"] == "cursor-abc"

--- a/tests/test_log_redact.py
+++ b/tests/test_log_redact.py
@@ -1,0 +1,139 @@
+"""
+Tests for ``lambdas.common.log_redact`` (admin-portal F5).
+
+Locks the server-side PII redaction contract applied to every
+CloudWatch log event before it leaves the backend. The three pinned
+patterns (email, Sleeper user id, Anthropic API key) cover every
+known leak shape; regressing them would be a privacy bug.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lambdas.common.log_redact import (
+    ANTHROPIC_KEY_RE,
+    EMAIL_RE,
+    SLEEPER_ID_RE,
+    redact,
+)
+
+
+class TestRedactEmail:
+    def test_simple_email(self) -> None:
+        assert redact("user@example.com") == "***@***"
+
+    def test_email_in_sentence(self) -> None:
+        assert (
+            redact("Sent welcome email to dominickj.giordano@gmail.com today.")
+            == "Sent welcome email to ***@*** today."
+        )
+
+    def test_plus_and_dot_local_part(self) -> None:
+        assert redact("foo.bar+tag@sub.example.co") == "***@***"
+
+    def test_email_in_json_escaped_string(self) -> None:
+        raw = '{"recipient_email": "alice@example.com"}'
+        assert "alice@example.com" not in redact(raw)
+        assert "***@***" in redact(raw)
+
+    def test_multiple_emails_in_one_line(self) -> None:
+        raw = "from a@b.io to c@d.io"
+        out = redact(raw)
+        assert "a@b.io" not in out
+        assert "c@d.io" not in out
+        assert out.count("***@***") == 2
+
+    def test_regex_isolation(self) -> None:
+        # Defense-in-depth: the EMAIL_RE alone matches as we expect.
+        assert EMAIL_RE.fullmatch("user@example.com") is not None
+
+
+class TestRedactSleeperId:
+    def test_18_digit_id(self) -> None:
+        assert redact("594625531702460416") == "[uid]"
+
+    def test_id_in_sentence(self) -> None:
+        assert (
+            redact("admin_gate: caller 594625531702460416 not found")
+            == "admin_gate: caller [uid] not found"
+        )
+
+    def test_15_digit_low_bound(self) -> None:
+        assert redact("123456789012345") == "[uid]"
+
+    def test_20_digit_high_bound(self) -> None:
+        assert redact("12345678901234567890") == "[uid]"
+
+    def test_14_digit_too_short_untouched(self) -> None:
+        """Sleeper IDs are always >= 15 digits today. 14-digit numerics
+        (e.g. unix epoch in microseconds) must NOT be matched."""
+        out = redact("ts=12345678901234 done")
+        assert "12345678901234" in out
+        assert "[uid]" not in out
+
+    def test_21_digit_too_long_untouched(self) -> None:
+        """Anything longer than 20 should not be classified as a
+        Sleeper id either (avoids gobbling hash-like blobs)."""
+        out = redact("hash=123456789012345678901 done")
+        assert "[uid]" not in out
+
+    def test_word_boundary_protects_alphanumeric_runs(self) -> None:
+        # `abc594625531702460416` should NOT redact — the ID isn't
+        # standing alone, it's a suffix on something else.
+        out = redact("abc594625531702460416")
+        assert "[uid]" not in out
+
+    def test_regex_isolation(self) -> None:
+        assert SLEEPER_ID_RE.fullmatch("594625531702460416") is not None
+
+
+class TestRedactAnthropicKey:
+    def test_canonical_key(self) -> None:
+        key = "sk-ant-api03-" + "A1B2C3D4E5F6G7H8I9J0"
+        assert redact(key) == "[key]"
+
+    def test_key_in_sentence(self) -> None:
+        key = "sk-ant-api03-" + "X" * 40
+        raw = f"using key={key} now"
+        out = redact(raw)
+        assert key not in out
+        assert "[key]" in out
+
+    def test_short_placeholder_untouched(self) -> None:
+        # `sk-ant-test` is too short for the 20+ tail; leave alone.
+        assert redact("placeholder sk-ant-test") == "placeholder sk-ant-test"
+
+    def test_regex_isolation(self) -> None:
+        assert ANTHROPIC_KEY_RE.fullmatch("sk-ant-" + "x" * 25) is not None
+
+
+class TestRedactComposite:
+    def test_all_three_in_one_line(self) -> None:
+        raw = (
+            "user dominickj.giordano@gmail.com (id 594625531702460416) "
+            "called with key sk-ant-api03-" + "z" * 30
+        )
+        out = redact(raw)
+        assert "dominickj.giordano@gmail.com" not in out
+        assert "594625531702460416" not in out
+        assert "sk-ant-api03-" not in out
+        assert "***@***" in out
+        assert "[uid]" in out
+        assert "[key]" in out
+
+    def test_clean_line_untouched(self) -> None:
+        raw = "INFO Starting weekly recap for league xyz."
+        assert redact(raw) == raw
+
+    def test_empty_string(self) -> None:
+        assert redact("") == ""
+
+
+class TestRedactDefensive:
+    """``redact`` is best-effort and must never raise — the lambda
+    pipes every CloudWatch event through it and a crash there would
+    break the entire tail."""
+
+    @pytest.mark.parametrize("bad", [None, 123, 4.5, {"a": 1}, ["x"], object()])
+    def test_non_string_inputs_return_empty(self, bad: object) -> None:
+        assert redact(bad) == ""  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Backend slice of admin-portal F5 — the CloudWatch log viewer. Adds a new admin-only lambda `GET /admin/logs-query` that wraps `boto3.client('logs').filter_log_events(...)` against a hard-coded allowlist of 10 lambda log groups, redacts PII server-side before returning, caches identical first-page queries for 60s, and paginates via `next_token`.

Closes #91. Related plan: `docs/features/admin-portal/f5-logs/PLAN.md` (in xomper-ios). Pairs with infra PR #111.

## What's in this PR

- `lambdas/common/log_redact.py` — three pinned regex patterns (`EMAIL_RE`, `SLEEPER_ID_RE`, `ANTHROPIC_KEY_RE`) + composite `redact()` helper. Best-effort, never raises.
- `lambdas/common/constants.py` — added `ADMIN_LOG_GROUP_ALLOWLIST` dict mapping API slugs to CloudWatch log group names (10 entries). Single source of truth shared with the IAM policy in infra PR #111.
- `lambdas/api_admin_logs_query/handler.py` — the lambda surface. Admin gate via `require_admin`. Defense-in-depth allowlist check (IAM also denies, but a 400 is friendlier than a boto AccessDenied). Module-level cache keyed by `(log_group, level, search, limit)` with 60s TTL; `next_token` bypasses entirely so pagination always re-fetches. Heuristic level detection via substring scan over the message. PII redaction applied to every returned event.
- `tests/test_log_redact.py` — 27 golden tests locking the PII contract (emails, sleeper IDs, anthropic keys, mixed lines, edge cases — 14-digit numerics untouched, word-boundary protection, embedded-JSON emails, non-string defensive paths).
- `tests/test_api_admin_logs_query.py` — 24 tests covering admin gate (403), allowlist validation (400 on missing/unknown), happy path with redaction integration, search + level filters, level detection heuristic, cache hit/miss/expiry/bypass, limit bounds clamping, pagination passthrough.

## Safety-critical pieces

- **Allowlist enforcement is defense in depth.** The lambda's IAM role (infra PR #111) already restricts `logs:FilterLogEvents` to exactly the 10 allowlisted log group ARNs. The handler validates again so callers see a clean 400 instead of an AccessDenied from boto3.
- **Server-side redaction is the choke point.** Every CloudWatch event's `message` field passes through `redact()` before the wire response is built. The iOS surface never sees the raw text. Regression-locked by `test_log_redact.py`.
- **60s cache** exists to dampen accidental polling, not to gate truth. Admin can also tail directly in CloudWatch console for sub-minute resolution. `next_token` paths skip the cache entirely so "Load older" never returns the cached first page.

## Test plan

- [x] All 475 backend tests pass (`pytest tests/`).
- [x] New `test_log_redact.py` (27 tests) green.
- [x] New `test_api_admin_logs_query.py` (24 tests) green.
- [ ] After infra PR #111 applies + this PR's deploy lands in dev, manual `curl` against `/admin/logs-query?log_group=ai-review-weekly` with an admin JWT to verify PII redaction in a real CloudWatch response.
- [ ] Hammer the endpoint 3x rapidly to verify the 60s cache (only 1 `FilterLogEvents` call in CloudWatch metrics within the window).

## Out of scope (this PR)

- Terraform IAM scoping + route registration — that's infra PR #111.
- iOS LogsView + LogsStore — follow-up PR after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)