### PR TITLE
feat(ai-review F3): generate per-matchup blurbs in metadata.matchups

### DIFF
--- a/lambdas/common/weekly_orchestrator.py
+++ b/lambdas/common/weekly_orchestrator.py
@@ -302,6 +302,17 @@ def run_weekly(
         sleeper_users=sleeper_users,
     )
 
+    # iOS surface (`MatchupBlurbCardView` on `MatchupsView`) decodes
+    # `metadata.matchups[]` per weekly report and renders the blurb
+    # under each matchup card. Built deterministically here so future
+    # live-week cron fires emit the same shape as the backfilled
+    # historical reports — see PR #91 / iOS `WeeklyMatchupBlurb`.
+    matchup_blurbs = _build_matchup_blurbs(
+        matchups_raw=matchups_raw,
+        rosters=rosters,
+        sleeper_users=sleeper_users,
+    )
+
     prior_memories = ai_memories_store.list_recent_memories(
         league_id, season, limit=AI_REVIEW_WEEKLY_MEMORY_LOOKBACK
     )
@@ -346,6 +357,11 @@ def run_weekly(
         "memory_count_out": 0,  # patched below post-write
         "envelope_parsed": parse_ok,
         "broadcast_at": None,
+        # Per-matchup blurbs for the iOS MatchupBlurbCardView surface.
+        # Empty list is safe (off-week / no matchups) — the iOS
+        # decoder treats a missing/empty array as "no blurbs to
+        # render" and the surface no-ops.
+        "matchups": matchup_blurbs,
     }
     if created_by_user_id:
         metadata["created_by_user_id"] = created_by_user_id
@@ -628,6 +644,237 @@ def _build_matchups(
 
     matchups.sort(key=lambda m: float(m.get("margin") or 0.0), reverse=True)
     return matchups
+
+
+# ---------------------------------------------------------------------------
+# Per-matchup blurbs (iOS `MatchupBlurbCardView` wire shape)
+# ---------------------------------------------------------------------------
+#
+# The historical 36-report backfill stamped `metadata.matchups[]` on
+# each weekly row by hand. The live cron + admin trigger must emit
+# the same shape so the iOS surface keeps rendering once the 2026
+# season opens. Generated DETERMINISTICALLY in Python (no LLM call)
+# from the same Sleeper data fetched for the prompt — see iOS
+# `WeeklyMatchupBlurb` decoder for the contract.
+
+
+# Margin bands -> template format strings. Tuple-ordered: the first
+# band whose threshold the margin meets wins. Sentinel `0.0` floor
+# catches ties via the explicit `winner == "tie"` short-circuit.
+# Keep the templates aligned with the backfilled historical voice.
+_BLURB_BANDS: tuple[tuple[float, str], ...] = (
+    (
+        60.0,
+        "**{winner_team} obliterated {loser_team} {wpts}-{lpts}** — "
+        "a {margin}-point shellacking that ended the conversation by "
+        "halftime.",
+    ),
+    (
+        40.0,
+        "**{winner_team} blew out {loser_team} {wpts}-{lpts}** — "
+        "{margin}-point margin, no nail-biting required.",
+    ),
+    (
+        20.0,
+        "**{winner_team} handled {loser_team} {wpts}-{lpts}** — "
+        "comfortable {margin}-point win, never in doubt.",
+    ),
+    (
+        8.0,
+        "**{winner_team} edged {loser_team} {wpts}-{lpts}** — "
+        "{margin}-point swing, one MNF performance away from "
+        "flipping.",
+    ),
+    (
+        3.0,
+        "**{winner_team} squeaked past {loser_team} {wpts}-{lpts}** "
+        "— a {margin}-point grinder. Both managers ran out the clock "
+        "with bench-checks.",
+    ),
+    (
+        0.0,
+        "**{winner_team} stole one from {loser_team} {wpts}-{lpts}** "
+        "— {margin}-point heartbreaker. {loser_handle} is reading "
+        "this with clenched jaw.",
+    ),
+)
+
+_BLURB_TIE_TEMPLATE = (
+    "**{team_a} {apts} TIED {team_b} {bpts}** — both teams stuck "
+    "the landing on the same number."
+)
+
+
+def _fmt_score(value: Any) -> str:
+    """Render a score as a one-decimal string (matches backfilled
+    template style: "204.9", "143.82" rounded to one place for
+    readability inside the blurb)."""
+    try:
+        return f"{float(value):.1f}"
+    except (TypeError, ValueError):
+        return "0.0"
+
+
+def render_matchup_blurb(matchup: dict[str, Any]) -> str:
+    """Render a deterministic one-line markdown blurb for a single
+    matchup. Pure function — no I/O, no LLM call.
+
+    Args:
+        matchup: Dict carrying at minimum `team_a`, `team_b`,
+            `handle_a`, `handle_b`, `score_a`, `score_b`, `margin`,
+            `winner` ("a" | "b" | "tie"). Scores + margin may be
+            floats OR strings (boto3-safe wire shape).
+
+    Returns:
+        Markdown blurb string. Always non-empty.
+    """
+    team_a = str(matchup.get("team_a") or "Team A")
+    team_b = str(matchup.get("team_b") or "Team B")
+    handle_a = str(matchup.get("handle_a") or team_a)
+    handle_b = str(matchup.get("handle_b") or team_b)
+    winner = str(matchup.get("winner") or "tie").lower()
+
+    try:
+        score_a = float(matchup.get("score_a") or 0.0)
+    except (TypeError, ValueError):
+        score_a = 0.0
+    try:
+        score_b = float(matchup.get("score_b") or 0.0)
+    except (TypeError, ValueError):
+        score_b = 0.0
+    try:
+        margin = float(matchup.get("margin") or 0.0)
+    except (TypeError, ValueError):
+        margin = 0.0
+
+    if winner == "tie":
+        return _BLURB_TIE_TEMPLATE.format(
+            team_a=team_a,
+            team_b=team_b,
+            apts=_fmt_score(score_a),
+            bpts=_fmt_score(score_b),
+        )
+
+    if winner == "a":
+        winner_team, loser_team = team_a, team_b
+        winner_handle, loser_handle = handle_a, handle_b
+        wpts, lpts = score_a, score_b
+    else:
+        winner_team, loser_team = team_b, team_a
+        winner_handle, loser_handle = handle_b, handle_a
+        wpts, lpts = score_b, score_a
+
+    abs_margin = abs(margin)
+    template = _BLURB_BANDS[-1][1]
+    for threshold, candidate in _BLURB_BANDS:
+        if abs_margin >= threshold:
+            template = candidate
+            break
+
+    return template.format(
+        winner_team=winner_team,
+        loser_team=loser_team,
+        winner_handle=winner_handle,
+        loser_handle=loser_handle,
+        wpts=_fmt_score(wpts),
+        lpts=_fmt_score(lpts),
+        margin=_fmt_score(abs_margin),
+    )
+
+
+def _build_matchup_blurbs(
+    *,
+    matchups_raw: list[dict[str, Any]],
+    rosters: list[dict[str, Any]],
+    sleeper_users: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build the iOS `metadata.matchups[]` wire shape from the same
+    raw Sleeper inputs used by `_build_matchups`. Preserves the
+    insertion order of the two sides per `matchup_id` as `team_a`
+    (first roster entry seen) and `team_b` (second), which keeps the
+    `winner` axis stable across re-runs.
+
+    Returns one dict per fully-paired matchup. Solo / un-paired
+    Sleeper entries (e.g., bye-week placeholders) are skipped — same
+    rule as `_build_matchups`. Empty list is a valid return.
+
+    Wire shape per entry (boto3-safe — scores + margin as strings):
+
+        {
+            "matchup_id": int,
+            "team_a": str, "team_b": str,
+            "handle_a": str, "handle_b": str,
+            "user_id_a": str, "user_id_b": str,
+            "score_a": str, "score_b": str,
+            "margin": str,
+            "winner": "a" | "b" | "tie",
+            "blurb": str,
+        }
+    """
+    users_by_id = {u.get("user_id"): u for u in sleeper_users}
+    roster_by_id = {r.get("roster_id"): r for r in rosters}
+
+    def _side_view(entry: dict[str, Any]) -> dict[str, Any]:
+        roster_id = entry.get("roster_id")
+        roster = roster_by_id.get(roster_id, {}) if roster_id else {}
+        owner_id = roster.get("owner_id") or ""
+        user = users_by_id.get(owner_id, {}) if owner_id else {}
+        team_name = (user.get("metadata") or {}).get("team_name") or (
+            user.get("display_name") or "Unknown"
+        )
+        handle = user.get("display_name") or "Unknown"
+        try:
+            points = float(entry.get("points") or 0.0)
+        except (TypeError, ValueError):
+            points = 0.0
+        return {
+            "team": team_name,
+            "handle": handle,
+            "user_id": str(owner_id) if owner_id else "",
+            "points": round(points, 2),
+        }
+
+    pairs: dict[int, list[dict[str, Any]]] = {}
+    for entry in matchups_raw:
+        mid = entry.get("matchup_id")
+        if mid is None:
+            continue
+        pairs.setdefault(mid, []).append(entry)
+
+    blurbs: list[dict[str, Any]] = []
+    for mid, group in pairs.items():
+        if len(group) != 2:
+            continue
+        a_raw, b_raw = group
+        a = _side_view(a_raw)
+        b = _side_view(b_raw)
+        margin_signed = round(a["points"] - b["points"], 2)
+        is_tie = abs(margin_signed) < 0.0001
+        if is_tie:
+            winner = "tie"
+        elif margin_signed > 0:
+            winner = "a"
+        else:
+            winner = "b"
+        margin_abs = round(abs(margin_signed), 2)
+
+        entry_dict: dict[str, Any] = {
+            "matchup_id": mid,
+            "team_a": a["team"],
+            "team_b": b["team"],
+            "handle_a": a["handle"],
+            "handle_b": b["handle"],
+            "user_id_a": a["user_id"],
+            "user_id_b": b["user_id"],
+            "score_a": str(a["points"]),
+            "score_b": str(b["points"]),
+            "margin": str(margin_abs),
+            "winner": winner,
+        }
+        entry_dict["blurb"] = render_matchup_blurb(entry_dict)
+        blurbs.append(entry_dict)
+
+    return blurbs
 
 
 def _parse_envelope(

--- a/tests/test_api_admin_ai_review_weekly_trigger.py
+++ b/tests/test_api_admin_ai_review_weekly_trigger.py
@@ -1465,3 +1465,355 @@ class TestHandlerPreviews:
         body = json.loads(response["body"])
         assert body["previews"] is None
         assert body["period"] == "2026W04"
+
+
+# ---------------------------------------------------------------------------
+# Per-matchup blurbs (iOS `MatchupBlurbCardView` surface)
+# ---------------------------------------------------------------------------
+#
+# The iOS `MatchupsView` decodes `metadata.matchups[]` per weekly
+# report and renders a per-matchup blurb under each card. The
+# historical 36-report backfill stamped the array inline; these
+# tests lock the live orchestrator path so future cron fires emit
+# the same shape.
+
+
+class TestRenderMatchupBlurb:
+    """Locks the deterministic margin-banded template renderer."""
+
+    def _base(self) -> dict[str, Any]:
+        return {
+            "matchup_id": 1,
+            "team_a": "Brock Party",
+            "team_b": "Gangsters of Love",
+            "handle_a": "domgiordano",
+            "handle_b": "ozz",
+            "user_id_a": "uA",
+            "user_id_b": "uB",
+        }
+
+    def test_obliterated_band_ge_60(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "204.9",
+            "score_b": "140.9",
+            "margin": "64.0",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "obliterated" in blurb
+        assert "shellacking" in blurb
+        assert "Brock Party" in blurb
+        assert "204.9" in blurb
+        assert "140.9" in blurb
+
+    def test_blew_out_band_ge_40(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "180.0",
+            "score_b": "135.0",
+            "margin": "45.0",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "blew out" in blurb
+        assert "no nail-biting" in blurb
+
+    def test_handled_band_ge_20(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "150.0",
+            "score_b": "125.0",
+            "margin": "25.0",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "handled" in blurb
+        assert "comfortable" in blurb
+
+    def test_edged_band_ge_8(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "132.3",
+            "score_b": "124.3",
+            "margin": "8.0",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "edged" in blurb
+        assert "MNF" in blurb
+
+    def test_squeaked_band_ge_3(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "120.0",
+            "score_b": "115.0",
+            "margin": "5.0",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "squeaked past" in blurb
+        assert "grinder" in blurb
+
+    def test_stole_one_band_lt_3(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "100.5",
+            "score_b": "99.0",
+            "margin": "1.5",
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "stole one" in blurb
+        assert "heartbreaker" in blurb
+        # Loser handle gets called out by name in the tightest band.
+        assert "ozz" in blurb
+
+    def test_tie_template(self) -> None:
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "110.0",
+            "score_b": "110.0",
+            "margin": "0.0",
+            "winner": "tie",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "TIED" in blurb
+        assert "Brock Party" in blurb
+        assert "Gangsters of Love" in blurb
+        assert "stuck the landing" in blurb
+
+    def test_winner_b_flips_team_order(self) -> None:
+        """When winner='b', the template names team_b as the winner."""
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": "100.0",
+            "score_b": "150.0",
+            "margin": "50.0",
+            "winner": "b",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "blew out" in blurb
+        # team_b name comes first as the winner.
+        assert blurb.index("Gangsters of Love") < blurb.index("Brock Party")
+
+    def test_accepts_numeric_scores(self) -> None:
+        """Scores as floats (not strings) still render cleanly —
+        defensive against shape drift."""
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        m = {
+            **self._base(),
+            "score_a": 145.7,
+            "score_b": 95.3,
+            "margin": 50.4,
+            "winner": "a",
+        }
+        blurb = render_matchup_blurb(m)
+        assert "blew out" in blurb
+        assert "145.7" in blurb
+        assert "95.3" in blurb
+
+    def test_band_boundaries_inclusive(self) -> None:
+        """Exact-threshold margins land in the higher band."""
+        from lambdas.common.weekly_orchestrator import render_matchup_blurb
+
+        # Exactly 60.0 -> obliterated band.
+        m60 = {
+            **self._base(),
+            "score_a": "200.0",
+            "score_b": "140.0",
+            "margin": "60.0",
+            "winner": "a",
+        }
+        assert "obliterated" in render_matchup_blurb(m60)
+
+        # Exactly 40.0 -> blew out band.
+        m40 = {
+            **self._base(),
+            "score_a": "175.0",
+            "score_b": "135.0",
+            "margin": "40.0",
+            "winner": "a",
+        }
+        assert "blew out" in render_matchup_blurb(m40)
+
+        # Exactly 20.0 -> handled band.
+        m20 = {
+            **self._base(),
+            "score_a": "150.0",
+            "score_b": "130.0",
+            "margin": "20.0",
+            "winner": "a",
+        }
+        assert "handled" in render_matchup_blurb(m20)
+
+        # Exactly 8.0 -> edged band.
+        m8 = {
+            **self._base(),
+            "score_a": "120.0",
+            "score_b": "112.0",
+            "margin": "8.0",
+            "winner": "a",
+        }
+        assert "edged" in render_matchup_blurb(m8)
+
+        # Exactly 3.0 -> squeaked band.
+        m3 = {
+            **self._base(),
+            "score_a": "110.0",
+            "score_b": "107.0",
+            "margin": "3.0",
+            "winner": "a",
+        }
+        assert "squeaked past" in render_matchup_blurb(m3)
+
+
+class TestOrchestratorMatchupBlurbsInMetadata:
+    """End-to-end through `run_weekly`: metadata.matchups must be
+    present, length-correct, and shaped for the iOS decoder."""
+
+    def test_metadata_matchups_present_and_length_matches(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(week=4, dry_run=True, force=False)
+        write = patched_orchestrator["writes"][0]
+        meta = write["metadata"]
+
+        assert "matchups" in meta
+        # _make_matchups() builds 6 head-to-heads across 12 rosters.
+        assert isinstance(meta["matchups"], list)
+        assert len(meta["matchups"]) == 6
+
+    def test_each_blurb_has_wire_shape_required_keys(
+        self, patched_orchestrator
+    ) -> None:
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+
+        required = {
+            "matchup_id",
+            "team_a",
+            "team_b",
+            "handle_a",
+            "handle_b",
+            "user_id_a",
+            "user_id_b",
+            "score_a",
+            "score_b",
+            "margin",
+            "winner",
+            "blurb",
+        }
+        for entry in meta["matchups"]:
+            assert required.issubset(entry.keys())
+            # boto3-safe: scores + margin must be strings.
+            assert isinstance(entry["score_a"], str)
+            assert isinstance(entry["score_b"], str)
+            assert isinstance(entry["margin"], str)
+            assert entry["winner"] in {"a", "b", "tie"}
+            assert isinstance(entry["blurb"], str) and entry["blurb"]
+
+    def test_empty_matchups_yields_empty_blurb_list(
+        self, patched_orchestrator
+    ) -> None:
+        """No matchups for the week (off-week / Sleeper hiccup) =>
+        empty list. Must not crash; must not omit the key."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        patched_orchestrator["matchups_by_league_week"][(LEAGUE_ID, 4)] = []
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+        assert meta["matchups"] == []
+
+    def test_blurb_strings_are_markdown_one_liners(
+        self, patched_orchestrator
+    ) -> None:
+        """Every emitted blurb opens with a bold markdown segment —
+        matches the backfilled historical voice."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+        for entry in meta["matchups"]:
+            assert entry["blurb"].startswith("**")
+
+    def test_winner_axis_consistent_with_scores(
+        self, patched_orchestrator
+    ) -> None:
+        """The `winner` enum must agree with the score_a/score_b
+        comparison. Decoder uses `winner` to drive a/b badges; any
+        mismatch leaks into the UI."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+        for entry in meta["matchups"]:
+            a = float(entry["score_a"])
+            b = float(entry["score_b"])
+            if abs(a - b) < 0.0001:
+                assert entry["winner"] == "tie"
+            elif a > b:
+                assert entry["winner"] == "a"
+            else:
+                assert entry["winner"] == "b"
+
+    def test_unpaired_matchups_skipped(
+        self, patched_orchestrator
+    ) -> None:
+        """Solo matchup entries (bye-week placeholder from Sleeper)
+        must not appear in the blurb list — same rule as the prompt
+        builder."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        # Build 5 normal pairs + 1 lone entry.
+        normal = _make_matchups(count=10)
+        normal.append(
+            {
+                "roster_id": 11,
+                "matchup_id": 99,
+                "points": 100.0,
+                "starters_points": [100.0],
+                "players_points": {"p11-0": 100.0},
+            }
+        )
+        patched_orchestrator["matchups_by_league_week"][(LEAGUE_ID, 4)] = normal
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+        # 5 pairs => 5 blurbs; the solo entry is dropped.
+        assert len(meta["matchups"]) == 5
+
+    def test_blurb_count_equals_matchup_pair_count(
+        self, patched_orchestrator
+    ) -> None:
+        """For arbitrary pair counts the emitted blurb list length
+        equals the number of fully-paired matchups."""
+        from lambdas.common.weekly_orchestrator import run_weekly
+
+        # 4 pairs across 8 rosters.
+        patched_orchestrator["matchups_by_league_week"][(LEAGUE_ID, 4)] = (
+            _make_matchups(count=8)
+        )
+        run_weekly(week=4, dry_run=True, force=False)
+        meta = patched_orchestrator["writes"][0]["metadata"]
+        assert len(meta["matchups"]) == 4


### PR DESCRIPTION
## Summary

The F3 weekly orchestrator now stamps `metadata.matchups[]` on every weekly report so future live cron fires match the wire shape of the 36 backfilled historical reports.

- The iOS surface (`MatchupBlurbCardView` on `MatchupsView`) decodes `metadata.matchups[]` per weekly report and renders the blurb under each individual matchup card. That surface is already wired and shipping — it just needs this data to render for future live weeks.
- Without this change, the F3 cron firing for 2026 Week 1 (Sept 2026) would write a report with no `matchups` array and the iOS per-matchup blurb cards would silently render nothing.
- Closes #91.

## Approach

**Deterministic Python — no LLM call.** A margin-banded template renderer (`render_matchup_blurb`) produces one-line markdown blurbs from the same raw Sleeper inputs already fetched for `_build_matchups`. No re-fetch, no extra Claude tokens, no JSON-parse risk.

Bands (margin in points):
- `>= 60` -> "obliterated ... shellacking"
- `>= 40` -> "blew out ... no nail-biting required"
- `>= 20` -> "handled ... comfortable"
- `>= 8`  -> "edged ... one MNF performance away"
- `>= 3`  -> "squeaked past ... grinder"
- `<  3`  -> "stole one ... heartbreaker"
- tie    -> "TIED ... stuck the landing on the same number"

## Wire shape (matches iOS `WeeklyMatchupBlurb` decoder)

```json
{
  "matchup_id": 1,
  "team_a": "Brock Party", "team_b": "Gangsters of Love",
  "handle_a": "domgiordano", "handle_b": "ozz",
  "user_id_a": "uA", "user_id_b": "uB",
  "score_a": "198.6", "score_b": "92.1", "margin": "106.5",
  "winner": "a",
  "blurb": "**Brock Party obliterated Gangsters of Love 198.6-92.1** — ..."
}
```

Scores + margin are strings (boto3-safe). `winner` is `"a" | "b" | "tie"`. iOS decoder accepts both string + numeric scores defensively — see `XomperTests/MockDraftMetadataTests.swift`.

## Files changed

- `lambdas/common/weekly_orchestrator.py` — new `render_matchup_blurb` + `_build_matchup_blurbs` helpers, wired into `metadata["matchups"]` before `write_report`.
- `tests/test_api_admin_ai_review_weekly_trigger.py` — 18 new tests across two classes (template bands, tie path, numeric vs string scores, end-to-end metadata shape, empty-matchups handling, unpaired-skip).

## Test plan

- [x] All 7 margin tiers + tie template render expected strings
- [x] `winner="b"` flips team order in the rendered blurb
- [x] Band boundaries inclusive (margin exactly 60.0 / 40.0 / 20.0 / 8.0 / 3.0)
- [x] Renderer accepts both string + numeric scores (boto3 round-trip safety)
- [x] `metadata.matchups[]` length equals fully-paired matchup count
- [x] Empty matchups list yields empty blurb array (no crash, key still present)
- [x] Unpaired Sleeper entries (bye-week placeholders) are skipped
- [x] `winner` enum agrees with score comparison
- [x] All 492 backend tests pass (no regressions in F0-F4 flows)

## Deviations

None.