### PR TITLE
feat(admin-cron-settings): backend — kill switch + test mode for all crons

### DIFF
--- a/lambdas/api_admin_cron_settings_list/handler.py
+++ b/lambdas/api_admin_cron_settings_list/handler.py
@@ -1,0 +1,68 @@
+"""
+GET /admin/cron-settings-list
+=============================
+Admin-only endpoint that returns every row from `admin_cron_settings`
+(admin-cron-settings F2). Powers the iOS CronSettingsView list.
+
+Query params:
+- sleeper_user_id  (required) — caller identity (admin gate).
+
+Response:
+{
+    "Success":       true,
+    "count":         N,
+    "rows":          [ ... admin_cron_settings rows ... ],
+    "table_missing": false  // true ONLY when the Supabase migration
+                            //   hasn't been applied yet (graceful
+                            //   empty-state fallback for iOS)
+}
+
+GRACEFUL FALLBACK — table_missing:
+    Mirrors api_admin_audit_list (F4). If the `admin_cron_settings`
+    Supabase table doesn't exist yet (the manual SQL migration hasn't
+    been applied), this endpoint returns `count=0, rows=[],
+    table_missing=true` with HTTP 200. The cron_settings helper logs
+    the failure at ERROR so CloudWatch surfaces the misconfiguration.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.admin_gate import NotAdmin, require_admin
+from lambdas.common.cron_settings import list_cron_settings
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import success_response
+
+log = get_logger(__file__)
+HANDLER = "api_admin_cron_settings_list"
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    log.info("Admin cron-settings-list request")
+
+    try:
+        require_admin(event)
+    except NotAdmin:
+        return success_response(
+            {"Success": False, "Message": "Not authorized"},
+            status_code=403,
+        )
+
+    rows = list_cron_settings()
+
+    # An empty list could mean "table missing" or "no rows yet"
+    # — but the migration seeds 5 rows so in practice an empty result
+    # is always the table_missing case. Mark it so iOS renders the
+    # right empty state.
+    table_missing = len(rows) == 0
+
+    return success_response(
+        {
+            "Success": True,
+            "count": len(rows),
+            "rows": rows,
+            "table_missing": table_missing,
+        }
+    )

--- a/lambdas/api_admin_cron_settings_update/handler.py
+++ b/lambdas/api_admin_cron_settings_update/handler.py
@@ -1,0 +1,185 @@
+"""
+POST /admin/cron-settings-update
+================================
+Admin-only endpoint that PATCHes one row in `admin_cron_settings`.
+Validates the `cron_key` against an allowlist (the five seeded
+lambdas) so an attacker can't insert a typo or invent a new key.
+
+Writes one row into `admin_audit` per successful update with
+`action="cron_settings.update"` capturing the before / after diff.
+
+Body:
+{
+    "sleeper_user_id": "abc123",      // required — admin gate identity
+    "email":           "user@.. ",    // optional fallback identity
+    "cron_key":        "notif_weekly_recap",   // required, must be allowlisted
+    "enabled":         true,                   // optional bool
+    "test_mode":       false                   // optional bool
+}
+
+At least one of `enabled` / `test_mode` MUST be supplied.
+
+Behavior:
+- 200 + Success=true on a successful update. Response carries the
+  resulting cron_key + enabled + test_mode + audit_id (when the audit
+  write succeeded).
+- 400 on bad input (missing cron_key, unknown cron_key, no toggleable
+  field supplied, non-bool value).
+- 403 when the caller is not an admin.
+- 404 when the cron_key row is missing (should never happen post-seed
+  but defensive — the helper raises NotFoundError).
+- 500 on Supabase / unexpected failure.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.admin_gate import NotAdmin, require_admin
+from lambdas.common.audit_log import write_audit
+from lambdas.common.cron_settings import get_cron_setting, update_cron_setting
+from lambdas.common.errors import NotFoundError, handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import parse_body, success_response
+
+log = get_logger(__file__)
+HANDLER = "api_admin_cron_settings_update"
+
+# Allowlist mirrors the five rows seeded by the migration. Any new cron
+# lambda needs an entry both here AND in the migration's seed insert.
+_ALLOWED_CRON_KEYS: tuple[str, ...] = (
+    "notif_weekly_recap",
+    "notif_lineup_not_set",
+    "notif_close_game_alert",
+    "notif_worldcup_movement",
+    "notif_ai_review_weekly",
+)
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    log.info("Admin cron-settings-update request")
+
+    body = parse_body(event)
+
+    try:
+        admin_user = require_admin(event, body)
+    except NotAdmin:
+        return success_response(
+            {"Success": False, "Message": "Not authorized"},
+            status_code=403,
+        )
+
+    cron_key = (body.get("cron_key") or "").strip()
+    if not cron_key:
+        return success_response(
+            {"Success": False, "Message": "Missing 'cron_key' in body"},
+            status_code=400,
+        )
+
+    if cron_key not in _ALLOWED_CRON_KEYS:
+        return success_response(
+            {
+                "Success": False,
+                "Message": (
+                    f"Unknown cron_key '{cron_key}'. "
+                    f"Allowed keys: {list(_ALLOWED_CRON_KEYS)}"
+                ),
+            },
+            status_code=400,
+        )
+
+    # Validate at least one of (enabled, test_mode) was supplied.
+    raw_enabled = body.get("enabled", None)
+    raw_test_mode = body.get("test_mode", None)
+    if raw_enabled is None and raw_test_mode is None:
+        return success_response(
+            {
+                "Success": False,
+                "Message": (
+                    "Body must include at least one of 'enabled' or "
+                    "'test_mode'."
+                ),
+            },
+            status_code=400,
+        )
+
+    try:
+        enabled = _coerce_bool(raw_enabled, "enabled") if raw_enabled is not None else None
+        test_mode = _coerce_bool(raw_test_mode, "test_mode") if raw_test_mode is not None else None
+    except ValueError as err:
+        return success_response(
+            {"Success": False, "Message": str(err)},
+            status_code=400,
+        )
+
+    # Snapshot the row BEFORE the update so the audit row carries the
+    # diff. get_cron_setting is best-effort; on Supabase outage it
+    # returns safe defaults — but in that case `update_cron_setting`
+    # below will raise too, so we won't actually mis-audit silently.
+    before_setting = get_cron_setting(cron_key)
+    before: dict[str, Any] = {}
+    if enabled is not None:
+        before["enabled"] = before_setting.get("enabled")
+    if test_mode is not None:
+        before["test_mode"] = before_setting.get("test_mode")
+
+    try:
+        updated = update_cron_setting(
+            cron_key=cron_key,
+            enabled=enabled,
+            test_mode=test_mode,
+        )
+    except NotFoundError as err:
+        # Defensive — the allowlist should make this unreachable since
+        # the migration seeds all five rows.
+        return success_response(
+            {"Success": False, "Message": str(err.message)},
+            status_code=404,
+        )
+
+    after: dict[str, Any] = {}
+    if enabled is not None:
+        after["enabled"] = bool(enabled)
+    if test_mode is not None:
+        after["test_mode"] = bool(test_mode)
+
+    # Best-effort audit write — failures NEVER fail the parent action
+    # (see audit_log.write_audit docstring).
+    actor = admin_user.get("sleeper_user_id") or admin_user.get("id") or "unknown"
+    audit_row = write_audit(
+        actor_user_id=str(actor),
+        action="cron_settings.update",
+        target_table="admin_cron_settings",
+        target_id=cron_key,
+        before=before,
+        after=after,
+    )
+    audit_id = (audit_row or {}).get("id") if audit_row else None
+
+    return success_response(
+        {
+            "Success": True,
+            "cron_key": cron_key,
+            "enabled": bool(updated.get("enabled", before_setting.get("enabled", True))),
+            "test_mode": bool(updated.get("test_mode", before_setting.get("test_mode", False))),
+            "before": before,
+            "after": after,
+            "audit_id": audit_id,
+        }
+    )
+
+
+def _coerce_bool(value: Any, key: str) -> bool:
+    """Same shape as api_admin_users_update — accepts real bools and
+    "true"/"false" string variants. Anything else is rejected."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+    raise ValueError(
+        f"Field '{key}' must be a boolean (true/false). Got: {value!r}"
+    )

--- a/lambdas/common/admin_only_filter.py
+++ b/lambdas/common/admin_only_filter.py
@@ -1,0 +1,58 @@
+"""
+admin_only_filter
+=================
+Shared helper for test-mode recipient filtering across all scheduled
+notif lambdas. When an admin flips a lambda's `test_mode=true` via the
+cron-settings admin UI, the lambda restricts delivery to admin
+(Dominick) only so we can preview the output before fanning out to
+the whole league.
+
+Kept here (rather than inline in each lambda) so the five notif
+lambdas share a single source of truth — preventing recipient-filter
+drift across handlers.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.constants import ADMIN_DOMINICK_USER_ID
+from lambdas.common.logger import get_logger
+
+log = get_logger(__file__)
+
+
+def filter_to_admin_only(
+    users: list[dict[str, Any]],
+    admin_user_id: str = ADMIN_DOMINICK_USER_ID,
+) -> list[dict[str, Any]]:
+    """Restrict a `whitelisted_users` row list to admin only.
+
+    Returns the matching row(s) — typically exactly one. When the
+    admin isn't present in the input list (misconfigured
+    whitelisted_users, or admin is inactive), returns `[]` and logs
+    at WARNING so CloudWatch surfaces the dead-letter test send.
+
+    Accepts the standard `whitelisted_users` shape — each row must
+    carry `sleeper_user_id`. Rows missing the field are ignored.
+    """
+    if not users:
+        log.warning(
+            "filter_to_admin_only: input user list was empty — "
+            "test-mode send will have no recipients"
+        )
+        return []
+
+    matched = [
+        u for u in users
+        if u.get("sleeper_user_id") == admin_user_id
+    ]
+
+    if not matched:
+        log.warning(
+            f"filter_to_admin_only: admin user_id={admin_user_id} not "
+            f"present in input list of {len(users)} user(s) — test-mode "
+            f"send will have no recipients"
+        )
+        return []
+
+    return matched

--- a/lambdas/common/cron_settings.py
+++ b/lambdas/common/cron_settings.py
@@ -1,0 +1,154 @@
+"""
+cron_settings helper
+====================
+Read/write helpers for the Supabase `admin_cron_settings` table.
+
+Each scheduled notif lambda owns one row keyed by `cron_key`. On cold
+start the lambda calls `get_cron_setting(cron_key)` to fetch its
+enabled + test_mode flags. The admin endpoints
+(`api_admin_cron_settings_list` + `api_admin_cron_settings_update`)
+use `list_cron_settings` + `update_cron_setting` to power the iOS
+admin UI.
+
+CRITICAL invariant — best-effort reads:
+    Supabase outages MUST NEVER block a scheduled lambda from
+    firing. The offseason guard is the actual safety belt; if our
+    settings table is unreachable we'd rather send a notification
+    than silently skip it. `get_cron_setting` therefore catches every
+    exception, logs a warning, and returns the safe default
+    `{enabled: True, test_mode: False, description: None,
+      cron_key: <key>}`.
+
+    `list_cron_settings` is similarly best-effort — returns `[]` on
+    failure (including the `table_missing` case where the migration
+    hasn't been applied yet). The api_admin_cron_settings_list
+    handler turns this into a `table_missing: true` flag for the iOS
+    empty state.
+
+    `update_cron_setting` is the only call that DOES raise — admin
+    edits need to surface failures so the iOS rollback path can fire.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.errors import NotFoundError
+from lambdas.common.logger import get_logger
+from lambdas.common.supabase_helper import get_row, list_rows, update_row
+
+log = get_logger(__file__)
+
+_TABLE = "admin_cron_settings"
+
+# Default returned by `get_cron_setting` when Supabase is unreachable or
+# the row is missing. "Send" is safer than "skip" — the offseason guard
+# remains the primary safety.
+_SAFE_DEFAULT: dict[str, Any] = {
+    "enabled": True,
+    "test_mode": False,
+    "description": None,
+}
+
+
+def get_cron_setting(cron_key: str) -> dict[str, Any]:
+    """Fetch one cron setting by `cron_key`. Best-effort.
+
+    Returns `{cron_key, enabled, test_mode, description}` where
+    `description` may be None. On Supabase failure OR a missing row,
+    returns the safe default (`enabled=True, test_mode=False,
+    description=None`). Never raises.
+    """
+    try:
+        row = get_row(_TABLE, "cron_key", cron_key)
+    except Exception as err:  # noqa: BLE001 — best-effort: never block
+        log.warning(
+            f"cron_settings.get_cron_setting: Supabase fetch failed for "
+            f"cron_key={cron_key} — defaulting to enabled=True, "
+            f"test_mode=False. error={err}"
+        )
+        return {**_SAFE_DEFAULT, "cron_key": cron_key}
+
+    if not row:
+        log.warning(
+            f"cron_settings.get_cron_setting: no row for cron_key={cron_key} "
+            f"— defaulting to enabled=True, test_mode=False"
+        )
+        return {**_SAFE_DEFAULT, "cron_key": cron_key}
+
+    return {
+        "cron_key": row.get("cron_key", cron_key),
+        "enabled": bool(row.get("enabled", True)),
+        "test_mode": bool(row.get("test_mode", False)),
+        "description": row.get("description"),
+    }
+
+
+def list_cron_settings() -> list[dict[str, Any]]:
+    """Return all cron settings ordered by `cron_key` ascending.
+
+    Best-effort: on any Supabase failure (including the table not
+    existing because the migration hasn't been applied yet), returns
+    `[]` and logs at ERROR so CloudWatch surfaces the misconfig. The
+    api_admin_cron_settings_list lambda turns the empty result into a
+    `table_missing: true` flag for iOS.
+    """
+    try:
+        rows, _ = list_rows(
+            _TABLE,
+            filters=None,
+            limit=200,
+            cursor=None,
+            order_by="cron_key.asc",
+        )
+    except Exception as err:  # noqa: BLE001 — graceful fallback
+        log.error(
+            f"cron_settings.list_cron_settings: fetch failed — returning "
+            f"empty list (likely table_missing). error={err}"
+        )
+        return []
+    return rows or []
+
+
+def update_cron_setting(
+    cron_key: str,
+    enabled: bool | None,
+    test_mode: bool | None,
+) -> dict[str, Any]:
+    """PATCH one cron setting row. Raises NotFoundError when the row
+    doesn't exist; lets Supabase HTTP errors propagate so the calling
+    endpoint can surface them.
+
+    At least one of `enabled` / `test_mode` must be non-None — the
+    caller is expected to validate this before calling.
+    """
+    fields: dict[str, Any] = {}
+    if enabled is not None:
+        fields["enabled"] = bool(enabled)
+    if test_mode is not None:
+        fields["test_mode"] = bool(test_mode)
+
+    if not fields:
+        # Defensive — handler should reject before getting here.
+        raise ValueError(
+            "cron_settings.update_cron_setting: nothing to update "
+            "(both 'enabled' and 'test_mode' were None)"
+        )
+
+    # Stamp updated_at on every patch so the UI's "last toggled" hint
+    # reflects the actual write moment (not whatever default Supabase
+    # would compute from triggers).
+    from lambdas.common.utility_helpers import get_iso_timestamp
+
+    fields["updated_at"] = get_iso_timestamp()
+
+    existing = get_row(_TABLE, "cron_key", cron_key)
+    if not existing:
+        raise NotFoundError(
+            message=f"cron_key not found: {cron_key}",
+            handler="cron_settings",
+            function="update_cron_setting",
+            resource=cron_key,
+        )
+
+    updated = update_row(_TABLE, "cron_key", cron_key, fields)
+    return updated or existing

--- a/lambdas/notif_ai_review_weekly/handler.py
+++ b/lambdas/notif_ai_review_weekly/handler.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.errors import handle_errors
 from lambdas.common.logger import get_logger
 from lambdas.common.utility_helpers import success_response
@@ -36,11 +37,28 @@ from lambdas.common.weekly_orchestrator import run_weekly
 
 log = get_logger(__file__)
 HANDLER = "notif_ai_review_weekly"
+LAMBDA_CRON_KEY = "notif_ai_review_weekly"
 
 
 @handle_errors(HANDLER)
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     log.info("Starting Weekly AI Review notification...")
+
+    # Admin cron settings gate (admin-cron-settings).
+    #   enabled=false  → no-op skip.
+    #   test_mode=true → forward as dry_run=True to the orchestrator,
+    #                    which reuses F3's existing admin-only delivery
+    #                    path (no separate recipient filter needed).
+    cron_setting = get_cron_setting(LAMBDA_CRON_KEY)
+    if not cron_setting["enabled"]:
+        log.info(
+            f"{LAMBDA_CRON_KEY} disabled via admin_cron_settings — skipping"
+        )
+        return success_response(
+            {"Success": True, "skipped": True, "reason": "disabled"},
+            is_api=False,
+        )
+    cron_test_mode = bool(cron_setting["test_mode"])
 
     # EventBridge `scheduled` events don't carry a body — fields are
     # at the top level when present. Tests + admin trigger
@@ -48,6 +66,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     overrides = event if isinstance(event, dict) else {}
     week_override = _coerce_int(overrides.get("week"))
     dry_run = _coerce_bool(overrides.get("dry_run"), default=False)
+    # When test_mode is enabled in admin_cron_settings, force dry_run on
+    # — admin-only delivery is exactly what dry_run already does in F3.
+    if cron_test_mode:
+        if not dry_run:
+            log.info(
+                f"{LAMBDA_CRON_KEY} test_mode=true — forcing dry_run=True "
+                f"(orchestrator will deliver to admin only)"
+            )
+        dry_run = True
     force = _coerce_bool(overrides.get("force"), default=False)
     seasons_back_raw = _coerce_int(overrides.get("seasons_back"))
     seasons_back = seasons_back_raw if seasons_back_raw is not None else 0

--- a/lambdas/notif_close_game_alert/handler.py
+++ b/lambdas/notif_close_game_alert/handler.py
@@ -20,6 +20,8 @@ concern.
 from datetime import datetime, timezone
 from typing import Any
 
+from lambdas.common.admin_only_filter import filter_to_admin_only
+from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -38,6 +40,7 @@ from lambdas.common.push_templates import close_game_push
 
 log = get_logger(__file__)
 HANDLER = "notif_close_game_alert"
+LAMBDA_CRON_KEY = "notif_close_game_alert"
 
 CLOSE_GAME_THRESHOLD = 10.0  # points
 
@@ -45,6 +48,18 @@ CLOSE_GAME_THRESHOLD = 10.0  # points
 @handle_errors(HANDLER)
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     log.info("Starting Close Game Alert notification...")
+
+    # Admin cron settings gate (admin-cron-settings).
+    cron_setting = get_cron_setting(LAMBDA_CRON_KEY)
+    if not cron_setting["enabled"]:
+        log.info(
+            f"{LAMBDA_CRON_KEY} disabled via admin_cron_settings — skipping"
+        )
+        return success_response(
+            {"Success": True, "skipped": True, "reason": "disabled"},
+            is_api=False,
+        )
+    test_mode = bool(cron_setting["test_mode"])
 
     league_row = get_active_whitelisted_league()
     if not league_row:
@@ -67,6 +82,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     roster_by_id = {r["roster_id"]: r for r in rosters}
 
     whitelisted = get_active_whitelisted_users()
+    if test_mode:
+        whitelisted = filter_to_admin_only(whitelisted)
+        log.info(
+            f"{LAMBDA_CRON_KEY} test_mode=true — restricting recipients to "
+            f"admin only ({len(whitelisted)} user(s))"
+        )
     sleeper_id_to_email = {
         w.get("sleeper_user_id"): w.get("email")
         for w in whitelisted

--- a/lambdas/notif_lineup_not_set/handler.py
+++ b/lambdas/notif_lineup_not_set/handler.py
@@ -11,6 +11,8 @@ Idempotency: re-runs of the same week regenerate the same reminder.
 A manager with no issues never gets pinged.
 """
 from typing import Any
+from lambdas.common.admin_only_filter import filter_to_admin_only
+from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -34,6 +36,7 @@ from lambdas.common.email_templates import (
 
 log = get_logger(__file__)
 HANDLER = "notif_lineup_not_set"
+LAMBDA_CRON_KEY = "notif_lineup_not_set"
 
 # A starter slot is considered "needs attention" when:
 # - empty / "0" placeholder
@@ -47,6 +50,18 @@ ACTIONABLE_INJURY_STATUSES = {"Out", "OUT", "IR", "Suspended", "PUP", "NA", "Dou
 @handle_errors(HANDLER)
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     log.info("Starting Lineup-Not-Set notification...")
+
+    # Admin cron settings gate (admin-cron-settings).
+    cron_setting = get_cron_setting(LAMBDA_CRON_KEY)
+    if not cron_setting["enabled"]:
+        log.info(
+            f"{LAMBDA_CRON_KEY} disabled via admin_cron_settings — skipping"
+        )
+        return success_response(
+            {"Success": True, "skipped": True, "reason": "disabled"},
+            is_api=False,
+        )
+    test_mode = bool(cron_setting["test_mode"])
 
     league_row = get_active_whitelisted_league()
     if not league_row:
@@ -67,6 +82,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     user_by_id = {u["user_id"]: u for u in users}
 
     whitelisted = get_active_whitelisted_users()
+    if test_mode:
+        whitelisted = filter_to_admin_only(whitelisted)
+        log.info(
+            f"{LAMBDA_CRON_KEY} test_mode=true — restricting recipients to "
+            f"admin only ({len(whitelisted)} user(s))"
+        )
     sleeper_id_to_user = {
         w.get("sleeper_user_id"): w
         for w in whitelisted

--- a/lambdas/notif_weekly_recap/handler.py
+++ b/lambdas/notif_weekly_recap/handler.py
@@ -17,6 +17,8 @@ content and sends again. Acceptable for a recap (low blast radius);
 if needed, gate behind a DynamoDB "last sent week" record.
 """
 from typing import Any
+from lambdas.common.admin_only_filter import filter_to_admin_only
+from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -41,11 +43,26 @@ from lambdas.common.email_templates import (
 
 log = get_logger(__file__)
 HANDLER = "notif_weekly_recap"
+LAMBDA_CRON_KEY = "notif_weekly_recap"
 
 
 @handle_errors(HANDLER)
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     log.info("Starting Weekly Recap notification...")
+
+    # 0. Admin cron settings gate (admin-cron-settings).
+    #    `enabled=false` → no-op skip. `test_mode=true` → restrict
+    #    recipient list to admin only before SES/SNS fan-out.
+    cron_setting = get_cron_setting(LAMBDA_CRON_KEY)
+    if not cron_setting["enabled"]:
+        log.info(
+            f"{LAMBDA_CRON_KEY} disabled via admin_cron_settings — skipping"
+        )
+        return success_response(
+            {"Success": True, "skipped": True, "reason": "disabled"},
+            is_api=False,
+        )
+    test_mode = bool(cron_setting["test_mode"])
 
     # 1. Resolve active league
     league_row = get_active_whitelisted_league()
@@ -100,6 +117,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     # 7. Resolve recipients from Supabase (sleeper_user_id → push + email)
     whitelisted = get_active_whitelisted_users()
+    if test_mode:
+        whitelisted = filter_to_admin_only(whitelisted)
+        log.info(
+            f"{LAMBDA_CRON_KEY} test_mode=true — restricting recipients to "
+            f"admin only ({len(whitelisted)} user(s))"
+        )
     sleeper_id_to_user = {
         w.get("sleeper_user_id"): w
         for w in whitelisted

--- a/lambdas/notif_worldcup_movement/handler.py
+++ b/lambdas/notif_worldcup_movement/handler.py
@@ -34,6 +34,8 @@ from typing import Any
 import boto3
 from boto3.dynamodb.conditions import Key
 
+from lambdas.common.admin_only_filter import filter_to_admin_only
+from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -67,6 +69,7 @@ from lambdas.common.worldcup_helper import (
 
 log = get_logger(__file__)
 HANDLER = "notif_worldcup_movement"
+LAMBDA_CRON_KEY = "notif_worldcup_movement"
 
 SNAPSHOT_TABLE = os.environ.get("APP_NAME", "xomper") + "-worldcup-snapshots"
 TOTAL_REGULAR_WEEKS = 17
@@ -77,6 +80,18 @@ _dynamodb = boto3.resource("dynamodb")
 @handle_errors(HANDLER)
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     log.info("Starting World Cup Movement notification...")
+
+    # Admin cron settings gate (admin-cron-settings).
+    cron_setting = get_cron_setting(LAMBDA_CRON_KEY)
+    if not cron_setting["enabled"]:
+        log.info(
+            f"{LAMBDA_CRON_KEY} disabled via admin_cron_settings — skipping"
+        )
+        return success_response(
+            {"Success": True, "skipped": True, "reason": "disabled"},
+            is_api=False,
+        )
+    test_mode = bool(cron_setting["test_mode"])
 
     league_row = get_active_whitelisted_league()
     if not league_row:
@@ -137,6 +152,12 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     # Resolve sleeper_user_id → push eligibility through whitelisted_users
     whitelisted = get_active_whitelisted_users()
+    if test_mode:
+        whitelisted = filter_to_admin_only(whitelisted)
+        log.info(
+            f"{LAMBDA_CRON_KEY} test_mode=true — restricting recipients to "
+            f"admin only ({len(whitelisted)} user(s))"
+        )
     eligible_user_ids = {
         w.get("sleeper_user_id")
         for w in whitelisted

--- a/sql/admin_cron_settings_migration.sql
+++ b/sql/admin_cron_settings_migration.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- admin_cron_settings migration
+-- ============================================================================
+--
+-- admin-cron-settings: per-lambda kill switch + test-mode flag for each
+-- scheduled notif lambda. One row per lambda. Read by every scheduled
+-- lambda on cold start via `lambdas/common/cron_settings.get_cron_setting`
+-- and updated by the admin endpoints `api_admin_cron_settings_list` +
+-- `api_admin_cron_settings_update`.
+--
+-- This file is the historical record of the schema. Apply mechanism (v1)
+-- is the Supabase dashboard SQL editor (the project doesn't yet have
+-- Terraform-Supabase integration). After applying, verify:
+--
+--     select count(*) from public.admin_cron_settings;   -- expect 5
+--
+-- Reapplication is safe (idempotent guards via `if not exists` /
+-- `on conflict do nothing`).
+-- ============================================================================
+
+create table if not exists public.admin_cron_settings (
+    cron_key     text        primary key,
+    enabled      boolean     not null default true,
+    test_mode    boolean     not null default false,
+    description  text,
+    updated_at   timestamptz not null default now()
+);
+
+-- Seed the five scheduled notif lambdas. `on conflict do nothing` keeps
+-- this idempotent: re-running the migration won't clobber any setting
+-- the admin has already toggled.
+insert into public.admin_cron_settings (cron_key, enabled, test_mode, description) values
+    ('notif_weekly_recap',       true, false, 'Weekly matchup recap — Tue 9am ET'),
+    ('notif_lineup_not_set',     true, false, 'Lineup-not-set alerts — Sun 11am ET'),
+    ('notif_close_game_alert',   true, false, 'Close-game alerts — Sun + Mon 8pm ET'),
+    ('notif_worldcup_movement',  true, false, 'World Cup transitions — Tue 10am ET'),
+    ('notif_ai_review_weekly',   true, false, 'AI weekly newsletter — Tue 2pm ET')
+on conflict (cron_key) do nothing;
+
+-- RLS: read + write restricted to service_role only. Lambdas authenticate
+-- with the service-role key (SSM /xomper/api/SUPABASE_SERVICE_KEY). End
+-- users have zero access to cron settings; admin clients fetch + patch
+-- via the admin-gated /admin/cron-settings-list + /admin/cron-settings-update
+-- lambdas which gate on `is_admin`.
+alter table public.admin_cron_settings enable row level security;

--- a/tests/test_admin_only_filter.py
+++ b/tests/test_admin_only_filter.py
@@ -1,0 +1,82 @@
+"""
+Tests for `lambdas.common.admin_only_filter`.
+
+Covers:
+  - Filters whitelisted user list to admin row only.
+  - Returns [] when admin is missing (and logs warning).
+  - Returns [] for empty input.
+  - Default admin_user_id is ADMIN_DOMINICK_USER_ID (the constant).
+  - Custom admin_user_id override works.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _admin_row() -> dict[str, Any]:
+    return {
+        "id": "row-admin",
+        "sleeper_user_id": ADMIN_ID,
+        "email": "admin@example.com",
+        "is_active": True,
+        "is_admin": True,
+    }
+
+
+def _other_user(sleeper_id: str) -> dict[str, Any]:
+    return {
+        "id": f"row-{sleeper_id}",
+        "sleeper_user_id": sleeper_id,
+        "email": f"{sleeper_id}@example.com",
+        "is_active": True,
+        "is_admin": False,
+    }
+
+
+class TestFilterToAdminOnly:
+    def test_admin_present_returns_admin_row(self) -> None:
+        from lambdas.common.admin_only_filter import filter_to_admin_only
+
+        users = [
+            _other_user("u1"),
+            _admin_row(),
+            _other_user("u2"),
+        ]
+        result = filter_to_admin_only(users)
+        assert len(result) == 1
+        assert result[0]["sleeper_user_id"] == ADMIN_ID
+
+    def test_admin_absent_returns_empty(self) -> None:
+        from lambdas.common.admin_only_filter import filter_to_admin_only
+
+        users = [_other_user("u1"), _other_user("u2")]
+        result = filter_to_admin_only(users)
+        assert result == []
+
+    def test_empty_input_returns_empty(self) -> None:
+        from lambdas.common.admin_only_filter import filter_to_admin_only
+
+        result = filter_to_admin_only([])
+        assert result == []
+
+    def test_custom_admin_id_override(self) -> None:
+        from lambdas.common.admin_only_filter import filter_to_admin_only
+
+        users = [_other_user("custom-id"), _admin_row()]
+        result = filter_to_admin_only(users, admin_user_id="custom-id")
+        assert len(result) == 1
+        assert result[0]["sleeper_user_id"] == "custom-id"
+
+    def test_rows_missing_sleeper_user_id_ignored(self) -> None:
+        from lambdas.common.admin_only_filter import filter_to_admin_only
+
+        users = [
+            {"id": "row-x"},  # no sleeper_user_id
+            _admin_row(),
+        ]
+        result = filter_to_admin_only(users)
+        assert len(result) == 1
+        assert result[0]["sleeper_user_id"] == ADMIN_ID

--- a/tests/test_api_admin_cron_settings_list.py
+++ b/tests/test_api_admin_cron_settings_list.py
@@ -1,0 +1,163 @@
+"""
+Tests for `api_admin_cron_settings_list` (admin-cron-settings).
+
+Endpoint shape: GET /admin/cron-settings-list
+
+Covers:
+  - 403 when caller not admin.
+  - Happy path returns the rows passed back by list_cron_settings,
+    with table_missing=false.
+  - Empty result triggers table_missing=true (the migration probably
+    hasn't been applied yet — helper degrades to [] on Supabase
+    failure).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _api_event(*, sleeper_user_id: str | None = ADMIN_ID) -> dict[str, Any]:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "GET",
+        "path": "/admin/cron-settings-list",
+        "headers": headers,
+        "queryStringParameters": {},
+    }
+
+
+def _seed_rows() -> list[dict[str, Any]]:
+    return [
+        {
+            "cron_key": "notif_ai_review_weekly",
+            "enabled": True,
+            "test_mode": False,
+            "description": "AI weekly newsletter — Tue 2pm ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+        {
+            "cron_key": "notif_close_game_alert",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Close-game alerts — Sun + Mon 8pm ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+        {
+            "cron_key": "notif_lineup_not_set",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Lineup-not-set alerts — Sun 11am ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+        {
+            "cron_key": "notif_weekly_recap",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Weekly matchup recap — Tue 9am ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+        {
+            "cron_key": "notif_worldcup_movement",
+            "enabled": True,
+            "test_mode": False,
+            "description": "World Cup transitions — Tue 10am ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+    ]
+
+
+@pytest.fixture
+def patched_handler(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.api_admin_cron_settings_list import handler as h
+
+    state: dict[str, Any] = {
+        "admin_row": {
+            "id": "row-admin",
+            "sleeper_user_id": ADMIN_ID,
+            "is_admin": True,
+            "is_active": True,
+        },
+        "rows": _seed_rows(),
+        "list_calls": 0,
+    }
+
+    def _require_admin(event, body=None):
+        return state["admin_row"]
+
+    def _list_cron_settings():
+        state["list_calls"] += 1
+        return list(state["rows"])
+
+    monkeypatch.setattr(h, "require_admin", _require_admin)
+    monkeypatch.setattr(h, "list_cron_settings", _list_cron_settings)
+
+    return state
+
+
+class TestAdminGate:
+    def test_non_admin_returns_403(
+        self, patched_handler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.api_admin_cron_settings_list import handler as h
+        from lambdas.common.admin_gate import NotAdmin
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body=None: (_ for _ in ()).throw(NotAdmin("nope")),
+        )
+        response = h.handler(_api_event(), context=None)
+        assert response["statusCode"] == 403
+        # Helper should NOT have been called.
+        assert patched_handler["list_calls"] == 0
+
+
+class TestHappyPath:
+    def test_returns_all_seeded_rows(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_list import handler as h
+
+        response = h.handler(_api_event(), context=None)
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["count"] == 5
+        assert body["table_missing"] is False
+        keys = [r["cron_key"] for r in body["rows"]]
+        assert "notif_weekly_recap" in keys
+        assert "notif_ai_review_weekly" in keys
+        assert "notif_close_game_alert" in keys
+        assert "notif_lineup_not_set" in keys
+        assert "notif_worldcup_movement" in keys
+
+    def test_payload_carries_all_columns(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_list import handler as h
+
+        body = json.loads(h.handler(_api_event(), context=None)["body"])
+        row = body["rows"][0]
+        assert {"cron_key", "enabled", "test_mode", "description", "updated_at"}.issubset(
+            row.keys()
+        )
+
+
+class TestTableMissingGracefulFallback:
+    """If the migration hasn't been applied yet, list_cron_settings
+    degrades to [] on Supabase failure. The endpoint must mark
+    table_missing=true so iOS renders an empty state."""
+
+    def test_empty_rows_marks_table_missing(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_list import handler as h
+
+        patched_handler["rows"] = []
+        response = h.handler(_api_event(), context=None)
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["count"] == 0
+        assert body["rows"] == []
+        assert body["table_missing"] is True

--- a/tests/test_api_admin_cron_settings_update.py
+++ b/tests/test_api_admin_cron_settings_update.py
@@ -1,0 +1,359 @@
+"""
+Tests for `api_admin_cron_settings_update` (admin-cron-settings).
+
+Endpoint shape: POST /admin/cron-settings-update, body
+  { cron_key, enabled?, test_mode? }
+
+Covers:
+  - 403 when caller not admin.
+  - 400 on missing cron_key.
+  - 400 on unknown cron_key (not in allowlist).
+  - 400 when neither enabled nor test_mode supplied.
+  - 400 on non-bool value.
+  - 404 when the row doesn't exist (cron_settings raises NotFoundError).
+  - Happy path: update_cron_setting + write_audit called once each.
+  - Bool coercion accepts "true"/"false" strings + real bools.
+  - Audit failure does not fail the parent action (best-effort).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+KEY = "notif_weekly_recap"
+
+
+def _api_event(
+    *,
+    body: dict[str, Any] | None = None,
+    sleeper_user_id: str | None = ADMIN_ID,
+) -> dict[str, Any]:
+    headers = {"X-Sleeper-User-Id": sleeper_user_id} if sleeper_user_id else {}
+    return {
+        "httpMethod": "POST",
+        "path": "/admin/cron-settings-update",
+        "headers": headers,
+        "body": json.dumps(body or {}),
+    }
+
+
+def _admin_row() -> dict[str, Any]:
+    return {
+        "id": "row-admin",
+        "sleeper_user_id": ADMIN_ID,
+        "is_active": True,
+        "is_admin": True,
+    }
+
+
+def _existing_row() -> dict[str, Any]:
+    return {
+        "cron_key": KEY,
+        "enabled": True,
+        "test_mode": False,
+        "description": "Weekly matchup recap — Tue 9am ET",
+        "updated_at": "2026-06-01T10:00:00Z",
+    }
+
+
+@pytest.fixture
+def patched_handler(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.api_admin_cron_settings_update import handler as h
+
+    state: dict[str, Any] = {
+        "admin_row": _admin_row(),
+        "existing_setting": _existing_row(),
+        "update_calls": [],
+        "audit_calls": [],
+        "audit_return": {"id": "audit-row-xyz"},
+        "update_raises": None,
+    }
+
+    def _require_admin(event, body=None):
+        return state["admin_row"]
+
+    def _get_cron_setting(cron_key: str):
+        row = state["existing_setting"]
+        if row and row.get("cron_key") == cron_key:
+            return {
+                "cron_key": row["cron_key"],
+                "enabled": bool(row["enabled"]),
+                "test_mode": bool(row["test_mode"]),
+                "description": row.get("description"),
+            }
+        # Safe default — mirrors helper behaviour
+        return {
+            "cron_key": cron_key,
+            "enabled": True,
+            "test_mode": False,
+            "description": None,
+        }
+
+    def _update_cron_setting(cron_key: str, enabled, test_mode):
+        state["update_calls"].append(
+            {"cron_key": cron_key, "enabled": enabled, "test_mode": test_mode}
+        )
+        if state["update_raises"] is not None:
+            raise state["update_raises"]
+        row = dict(state["existing_setting"] or {})
+        if enabled is not None:
+            row["enabled"] = bool(enabled)
+        if test_mode is not None:
+            row["test_mode"] = bool(test_mode)
+        state["existing_setting"] = row
+        return row
+
+    def _write_audit(**kwargs):
+        state["audit_calls"].append(kwargs)
+        return state["audit_return"]
+
+    monkeypatch.setattr(h, "require_admin", _require_admin)
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(h, "update_cron_setting", _update_cron_setting)
+    monkeypatch.setattr(h, "write_audit", _write_audit)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+
+class TestAdminGate:
+    def test_non_admin_returns_403(
+        self, patched_handler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+        from lambdas.common.admin_gate import NotAdmin
+
+        monkeypatch.setattr(
+            h,
+            "require_admin",
+            lambda event, body=None: (_ for _ in ()).throw(NotAdmin("nope")),
+        )
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 403
+        assert patched_handler["update_calls"] == []
+        assert patched_handler["audit_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_missing_cron_key_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"enabled": True}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "cron_key" in body["Message"]
+        assert patched_handler["update_calls"] == []
+
+    def test_unknown_cron_key_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": "notif_bogus", "enabled": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "notif_bogus" in body["Message"]
+        assert patched_handler["update_calls"] == []
+
+    def test_no_field_supplied_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "enabled" in body["Message"]
+        assert "test_mode" in body["Message"]
+        assert patched_handler["update_calls"] == []
+
+    def test_non_bool_enabled_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": "maybe"}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        body = json.loads(response["body"])
+        assert "enabled" in body["Message"].lower()
+        assert patched_handler["update_calls"] == []
+
+    def test_non_bool_test_mode_returns_400(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "test_mode": 42}),
+            context=None,
+        )
+        assert response["statusCode"] == 400
+        assert patched_handler["update_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Bool coercion
+# ---------------------------------------------------------------------------
+
+
+class TestBoolCoercion:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (True, True),
+            (False, False),
+            ("true", True),
+            ("false", False),
+            ("TRUE", True),
+            ("False", False),
+        ],
+    )
+    def test_enabled_coerces(self, patched_handler, raw, expected) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": raw}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        call = patched_handler["update_calls"][0]
+        assert call["enabled"] is expected
+
+
+# ---------------------------------------------------------------------------
+# Lookup failure
+# ---------------------------------------------------------------------------
+
+
+class TestLookupFailure:
+    def test_not_found_returns_404(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+        from lambdas.common.errors import NotFoundError
+
+        patched_handler["update_raises"] = NotFoundError(
+            message=f"cron_key not found: {KEY}",
+            resource=KEY,
+        )
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 404
+        assert patched_handler["audit_calls"] == []
+
+
+# ---------------------------------------------------------------------------
+# Happy path + audit
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_enabled_only_patch_writes_audit(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["cron_key"] == KEY
+        assert body["enabled"] is False
+        # test_mode unchanged in the response (since we only patched enabled).
+        assert body["test_mode"] is False
+        assert body["audit_id"] == "audit-row-xyz"
+
+        # update_cron_setting called once
+        assert len(patched_handler["update_calls"]) == 1
+        call = patched_handler["update_calls"][0]
+        assert call["cron_key"] == KEY
+        assert call["enabled"] is False
+        assert call["test_mode"] is None
+
+        # Audit row carries the before/after diff
+        assert len(patched_handler["audit_calls"]) == 1
+        audit = patched_handler["audit_calls"][0]
+        assert audit["action"] == "cron_settings.update"
+        assert audit["target_table"] == "admin_cron_settings"
+        assert audit["target_id"] == KEY
+        assert audit["before"] == {"enabled": True}
+        assert audit["after"] == {"enabled": False}
+        assert audit["actor_user_id"] == ADMIN_ID
+
+    def test_test_mode_only_patch(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        body = json.loads(
+            h.handler(
+                _api_event(body={"cron_key": KEY, "test_mode": True}),
+                context=None,
+            )["body"]
+        )
+        assert body["test_mode"] is True
+        assert body["enabled"] is True  # unchanged
+        # audit captures only the test_mode diff
+        audit = patched_handler["audit_calls"][0]
+        assert audit["before"] == {"test_mode": False}
+        assert audit["after"] == {"test_mode": True}
+
+    def test_both_fields_patch(self, patched_handler) -> None:
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        body = json.loads(
+            h.handler(
+                _api_event(
+                    body={
+                        "cron_key": KEY,
+                        "enabled": False,
+                        "test_mode": True,
+                    }
+                ),
+                context=None,
+            )["body"]
+        )
+        assert body["enabled"] is False
+        assert body["test_mode"] is True
+        audit = patched_handler["audit_calls"][0]
+        assert audit["before"] == {"enabled": True, "test_mode": False}
+        assert audit["after"] == {"enabled": False, "test_mode": True}
+
+    def test_audit_write_failure_does_not_break_response(
+        self, patched_handler
+    ) -> None:
+        """Best-effort audit write — when write_audit returns None,
+        the parent action still succeeds and returns 200."""
+        from lambdas.api_admin_cron_settings_update import handler as h
+
+        patched_handler["audit_return"] = None
+        response = h.handler(
+            _api_event(body={"cron_key": KEY, "enabled": False}),
+            context=None,
+        )
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+        assert body["Success"] is True
+        assert body["audit_id"] is None
+        # The update still happened.
+        assert len(patched_handler["update_calls"]) == 1

--- a/tests/test_cron_settings.py
+++ b/tests/test_cron_settings.py
@@ -1,0 +1,253 @@
+"""
+Tests for `lambdas.common.cron_settings` (admin-cron-settings).
+
+Covers:
+  - get_cron_setting happy path: returns row fields.
+  - get_cron_setting best-effort defaults on Supabase failure:
+    returns enabled=True, test_mode=False, never raises.
+  - get_cron_setting safe default when row is missing (None).
+  - list_cron_settings happy path: returns rows via list_rows.
+  - list_cron_settings graceful empty list on Supabase failure
+    (table_missing scenario).
+  - update_cron_setting happy path: PATCHes only the supplied fields,
+    stamps updated_at, returns the merged row.
+  - update_cron_setting raises NotFoundError when row is missing.
+  - update_cron_setting raises ValueError when nothing to update.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+KEY = "notif_weekly_recap"
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    """Stub get_row / list_rows / update_row so the helper can be
+    exercised without touching Supabase."""
+    from lambdas.common import cron_settings as cs
+
+    state: dict[str, Any] = {
+        "row": {
+            "cron_key": KEY,
+            "enabled": True,
+            "test_mode": False,
+            "description": "Weekly matchup recap — Tue 9am ET",
+            "updated_at": "2026-06-01T10:00:00Z",
+        },
+        "get_calls": [],
+        "list_calls": [],
+        "update_calls": [],
+        "get_raises": None,
+        "list_raises": None,
+        "list_response": None,  # if set, overrides default
+    }
+
+    def _get_row(table: str, column: str, value: str):
+        state["get_calls"].append({"table": table, "column": column, "value": value})
+        if state["get_raises"] is not None:
+            raise state["get_raises"]
+        row = state["row"]
+        if row and row.get(column) == value:
+            return row
+        return None
+
+    def _list_rows(table: str, **kwargs: Any):
+        state["list_calls"].append({"table": table, **kwargs})
+        if state["list_raises"] is not None:
+            raise state["list_raises"]
+        if state["list_response"] is not None:
+            return state["list_response"]
+        return ([state["row"]] if state["row"] else [], None)
+
+    def _update_row(table: str, column: str, value: str, fields: dict[str, Any]):
+        state["update_calls"].append(
+            {"table": table, "column": column, "value": value, "fields": fields}
+        )
+        merged = dict(state["row"] or {})
+        merged.update(fields)
+        state["row"] = merged
+        return merged
+
+    monkeypatch.setattr(cs, "get_row", _get_row)
+    monkeypatch.setattr(cs, "list_rows", _list_rows)
+    monkeypatch.setattr(cs, "update_row", _update_row)
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# get_cron_setting
+# ---------------------------------------------------------------------------
+
+
+class TestGetCronSetting:
+    def test_happy_path_returns_row_fields(self, patched) -> None:
+        from lambdas.common.cron_settings import get_cron_setting
+
+        result = get_cron_setting(KEY)
+        assert result == {
+            "cron_key": KEY,
+            "enabled": True,
+            "test_mode": False,
+            "description": "Weekly matchup recap — Tue 9am ET",
+        }
+        # Lookup uses cron_key column.
+        call = patched["get_calls"][0]
+        assert call["table"] == "admin_cron_settings"
+        assert call["column"] == "cron_key"
+        assert call["value"] == KEY
+
+    def test_supabase_failure_returns_safe_default(self, patched) -> None:
+        """Best-effort: any exception from Supabase falls back to
+        enabled=True, test_mode=False so the cron still fires."""
+        from lambdas.common.cron_settings import get_cron_setting
+
+        patched["get_raises"] = Exception("network timeout")
+
+        result = get_cron_setting(KEY)
+        assert result["enabled"] is True
+        assert result["test_mode"] is False
+        assert result["description"] is None
+        assert result["cron_key"] == KEY
+
+    def test_missing_row_returns_safe_default(self, patched) -> None:
+        """If the row simply doesn't exist (migration partial, or a
+        new cron not yet seeded), same safe default applies."""
+        from lambdas.common.cron_settings import get_cron_setting
+
+        patched["row"] = None
+
+        result = get_cron_setting(KEY)
+        assert result["enabled"] is True
+        assert result["test_mode"] is False
+        assert result["cron_key"] == KEY
+
+    def test_disabled_row_propagates(self, patched) -> None:
+        from lambdas.common.cron_settings import get_cron_setting
+
+        patched["row"] = {
+            "cron_key": KEY,
+            "enabled": False,
+            "test_mode": False,
+            "description": "off",
+        }
+        result = get_cron_setting(KEY)
+        assert result["enabled"] is False
+
+    def test_test_mode_row_propagates(self, patched) -> None:
+        from lambdas.common.cron_settings import get_cron_setting
+
+        patched["row"] = {
+            "cron_key": KEY,
+            "enabled": True,
+            "test_mode": True,
+            "description": "preview",
+        }
+        result = get_cron_setting(KEY)
+        assert result["test_mode"] is True
+
+    def test_never_raises_even_on_unexpected_supabase_shape(self, patched) -> None:
+        """Defensive: arbitrary Exception subclasses are swallowed."""
+        from lambdas.common.cron_settings import get_cron_setting
+
+        class _Boom(RuntimeError):
+            pass
+
+        patched["get_raises"] = _Boom("kaboom")
+        # Should NOT propagate.
+        assert get_cron_setting(KEY)["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# list_cron_settings
+# ---------------------------------------------------------------------------
+
+
+class TestListCronSettings:
+    def test_happy_path_returns_rows(self, patched) -> None:
+        from lambdas.common.cron_settings import list_cron_settings
+
+        result = list_cron_settings()
+        assert len(result) == 1
+        assert result[0]["cron_key"] == KEY
+        # Ordering query plumbs through.
+        call = patched["list_calls"][0]
+        assert call["order_by"] == "cron_key.asc"
+
+    def test_supabase_failure_returns_empty_list(self, patched) -> None:
+        """table_missing scenario — Supabase returns 404 because the
+        migration hasn't been applied. Helper degrades to []."""
+        from lambdas.common.cron_settings import list_cron_settings
+        from lambdas.common.errors import SleeperAPIError
+
+        patched["list_raises"] = SleeperAPIError(
+            message="HTTP 404 — relation public.admin_cron_settings does not exist",
+            function="supabase_helper._get",
+        )
+
+        result = list_cron_settings()
+        assert result == []
+
+    def test_arbitrary_exception_returns_empty_list(self, patched) -> None:
+        from lambdas.common.cron_settings import list_cron_settings
+
+        patched["list_raises"] = RuntimeError("network down")
+        assert list_cron_settings() == []
+
+
+# ---------------------------------------------------------------------------
+# update_cron_setting
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCronSetting:
+    def test_patch_enabled_only(self, patched) -> None:
+        from lambdas.common.cron_settings import update_cron_setting
+
+        result = update_cron_setting(KEY, enabled=False, test_mode=None)
+        assert result["enabled"] is False
+        # Only `enabled` + `updated_at` should appear in fields.
+        write = patched["update_calls"][0]
+        assert "enabled" in write["fields"]
+        assert write["fields"]["enabled"] is False
+        assert "test_mode" not in write["fields"]
+        assert "updated_at" in write["fields"]
+
+    def test_patch_test_mode_only(self, patched) -> None:
+        from lambdas.common.cron_settings import update_cron_setting
+
+        update_cron_setting(KEY, enabled=None, test_mode=True)
+        write = patched["update_calls"][0]
+        assert "test_mode" in write["fields"]
+        assert write["fields"]["test_mode"] is True
+        assert "enabled" not in write["fields"]
+
+    def test_patch_both(self, patched) -> None:
+        from lambdas.common.cron_settings import update_cron_setting
+
+        update_cron_setting(KEY, enabled=False, test_mode=True)
+        write = patched["update_calls"][0]
+        assert write["fields"]["enabled"] is False
+        assert write["fields"]["test_mode"] is True
+
+    def test_missing_row_raises_not_found(self, patched) -> None:
+        from lambdas.common.cron_settings import update_cron_setting
+        from lambdas.common.errors import NotFoundError
+
+        patched["row"] = None
+
+        with pytest.raises(NotFoundError):
+            update_cron_setting(KEY, enabled=True, test_mode=None)
+        # No update call should have fired.
+        assert patched["update_calls"] == []
+
+    def test_nothing_to_update_raises_value_error(self, patched) -> None:
+        from lambdas.common.cron_settings import update_cron_setting
+
+        with pytest.raises(ValueError):
+            update_cron_setting(KEY, enabled=None, test_mode=None)
+        assert patched["update_calls"] == []

--- a/tests/test_notif_ai_review_weekly_settings_gate.py
+++ b/tests/test_notif_ai_review_weekly_settings_gate.py
@@ -1,0 +1,101 @@
+"""
+Tests for the admin-cron-settings gate inside `notif_ai_review_weekly`.
+
+This lambda is structurally different from the other four — its
+recipient filter lives inside the F3 weekly orchestrator's `dry_run`
+path. The gate's job here is:
+  - enabled=False → no-op skip.
+  - test_mode=True → force `dry_run=True` on the orchestrator call,
+    even if the inbound event passed `dry_run=False`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.notif_ai_review_weekly import handler as h
+
+    state: dict[str, Any] = {
+        "cron_setting": {
+            "cron_key": "notif_ai_review_weekly",
+            "enabled": True,
+            "test_mode": False,
+            "description": "AI",
+        },
+        "run_calls": [],
+    }
+
+    def _get_cron_setting(cron_key: str):
+        return dict(state["cron_setting"])
+
+    def _run_weekly(**kwargs: Any) -> dict[str, Any]:
+        state["run_calls"].append(kwargs)
+        return {
+            "status": "broadcast",
+            "dry_run": kwargs.get("dry_run", False),
+            "delivery_count": 1 if kwargs.get("dry_run") else 12,
+            "model": "claude-haiku-4-5",
+            "token_usage": {"input_tokens": 100, "output_tokens": 50},
+            "week": kwargs.get("week") or 4,
+            "period": "2026W04",
+            "memory_count_in": 0,
+            "memory_count_out": 0,
+            "envelope_parsed": True,
+        }
+
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(h, "run_weekly", _run_weekly)
+    return state
+
+
+class TestDisabledShortCircuit:
+    def test_disabled_returns_skipped_without_calling_orchestrator(
+        self, patched
+    ) -> None:
+        from lambdas.notif_ai_review_weekly.handler import handler
+
+        patched["cron_setting"]["enabled"] = False
+        response = handler({}, context=None)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        if isinstance(body, str):
+            import json
+
+            body = json.loads(body)
+        assert body["skipped"] is True
+        assert body["reason"] == "disabled"
+        # Orchestrator should not be invoked.
+        assert patched["run_calls"] == []
+
+
+class TestTestModeForcesDryRun:
+    def test_test_mode_true_forces_dry_run(self, patched) -> None:
+        from lambdas.notif_ai_review_weekly.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        handler({"dry_run": False}, context=None)
+
+        assert len(patched["run_calls"]) == 1
+        call = patched["run_calls"][0]
+        # Even though the event explicitly passed dry_run=False, the
+        # cron_settings test_mode flag must override to True.
+        assert call["dry_run"] is True
+
+    def test_test_mode_false_preserves_event_dry_run(self, patched) -> None:
+        from lambdas.notif_ai_review_weekly.handler import handler
+
+        patched["cron_setting"]["test_mode"] = False
+        handler({"dry_run": True}, context=None)
+        # Event-supplied dry_run still flows through.
+        assert patched["run_calls"][0]["dry_run"] is True
+
+    def test_default_settings_no_dry_run(self, patched) -> None:
+        from lambdas.notif_ai_review_weekly.handler import handler
+
+        handler({}, context=None)
+        assert patched["run_calls"][0]["dry_run"] is False

--- a/tests/test_notif_close_game_alert_settings_gate.py
+++ b/tests/test_notif_close_game_alert_settings_gate.py
@@ -1,0 +1,125 @@
+"""
+Tests for the admin-cron-settings gate inside `notif_close_game_alert`.
+
+Covers:
+  - enabled=False short-circuits before any data fetch + send.
+  - test_mode=True restricts recipient list to admin only.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _user_row(sleeper_id: str, *, idx: int) -> dict[str, Any]:
+    return {
+        "sleeper_user_id": sleeper_id,
+        "email": f"u{idx}@example.com",
+        "is_active": True,
+        "is_admin": sleeper_id == ADMIN_ID,
+    }
+
+
+def _close_matchups() -> list[dict[str, Any]]:
+    """One pair within the close-game threshold (110 vs 105)."""
+    return [
+        {"matchup_id": 1, "roster_id": 1, "points": 110.0},
+        {"matchup_id": 1, "roster_id": 2, "points": 105.0},
+    ]
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.notif_close_game_alert import handler as h
+
+    state: dict[str, Any] = {
+        "cron_setting": {
+            "cron_key": "notif_close_game_alert",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Close",
+        },
+        "whitelisted": [_user_row(ADMIN_ID, idx=0), _user_row("user-1", idx=1)],
+        "send_push_calls": [],
+    }
+
+    def _get_cron_setting(cron_key: str):
+        return dict(state["cron_setting"])
+
+    def _send_push_to_users(user_ids, title, body, category, data):
+        state["send_push_calls"].append({"user_ids": list(user_ids)})
+
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(
+        h,
+        "get_active_whitelisted_league",
+        lambda: {"league_id": "L1", "league_name": "Test"},
+    )
+    monkeypatch.setattr(
+        h, "get_active_whitelisted_users", lambda: list(state["whitelisted"])
+    )
+    monkeypatch.setattr(
+        h,
+        "get_sleeper_league_rosters",
+        lambda lid: [
+            {"roster_id": 1, "owner_id": ADMIN_ID},
+            {"roster_id": 2, "owner_id": "user-1"},
+        ],
+    )
+    monkeypatch.setattr(
+        h,
+        "get_sleeper_league_users",
+        lambda lid: [
+            {"user_id": ADMIN_ID, "display_name": "Admin"},
+            {"user_id": "user-1", "display_name": "U1"},
+        ],
+    )
+    monkeypatch.setattr(h, "get_sleeper_league_matchups", lambda lid, w: _close_matchups())
+    monkeypatch.setattr(h, "get_nfl_state", lambda: {"week": 4, "season": "2026"})
+    monkeypatch.setattr(h, "send_push_to_users", _send_push_to_users)
+
+    return state
+
+
+class TestDisabledShortCircuit:
+    def test_disabled_returns_skipped(self, patched) -> None:
+        from lambdas.notif_close_game_alert.handler import handler
+
+        patched["cron_setting"]["enabled"] = False
+        response = handler({}, context=None)
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert body["skipped"] is True
+        assert patched["send_push_calls"] == []
+
+
+class TestTestModeFiltering:
+    def test_test_mode_filters_to_admin_only(self, patched) -> None:
+        from lambdas.notif_close_game_alert.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        handler({}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert recipients == {ADMIN_ID}
+
+
+class TestDefaultPassthrough:
+    def test_default_unfiltered_fan_out(self, patched) -> None:
+        from lambdas.notif_close_game_alert.handler import handler
+
+        handler({}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert ADMIN_ID in recipients
+        assert "user-1" in recipients

--- a/tests/test_notif_lineup_not_set_settings_gate.py
+++ b/tests/test_notif_lineup_not_set_settings_gate.py
@@ -1,0 +1,138 @@
+"""
+Tests for the admin-cron-settings gate inside `notif_lineup_not_set`.
+
+Covers:
+  - enabled=False short-circuits before any data fetch + send.
+  - test_mode=True restricts recipient list to admin only.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _user_row(sleeper_id: str, *, idx: int) -> dict[str, Any]:
+    return {
+        "sleeper_user_id": sleeper_id,
+        "email": f"u{idx}@example.com",
+        "display_name": f"U{idx}",
+        "is_active": True,
+        "is_admin": sleeper_id == ADMIN_ID,
+    }
+
+
+def _rosters_with_actionable_lineups() -> list[dict[str, Any]]:
+    """Every roster has a starter marked OUT so each manager gets a ping."""
+    return [
+        {"roster_id": 1, "owner_id": ADMIN_ID, "starters": ["P_OUT"]},
+        {"roster_id": 2, "owner_id": "user-1", "starters": ["P_OUT"]},
+        {"roster_id": 3, "owner_id": "user-2", "starters": ["P_OUT"]},
+    ]
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.notif_lineup_not_set import handler as h
+
+    state: dict[str, Any] = {
+        "cron_setting": {
+            "cron_key": "notif_lineup_not_set",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Lineup",
+        },
+        "whitelisted": [
+            _user_row(ADMIN_ID, idx=0),
+            _user_row("user-1", idx=1),
+            _user_row("user-2", idx=2),
+        ],
+        "send_push_calls": [],
+        "send_email_call": None,
+    }
+
+    def _get_cron_setting(cron_key: str):
+        return dict(state["cron_setting"])
+
+    def _send_push_to_users(user_ids, title, body, category, data):
+        state["send_push_calls"].append({"user_ids": list(user_ids)})
+
+    def _send_emails(tasks):
+        state["send_email_call"] = list(tasks)
+        return (len(tasks), 0)
+
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(
+        h,
+        "get_active_whitelisted_league",
+        lambda: {"league_id": "L1", "league_name": "Test"},
+    )
+    monkeypatch.setattr(
+        h, "get_active_whitelisted_users", lambda: list(state["whitelisted"])
+    )
+    monkeypatch.setattr(
+        h, "get_sleeper_league_rosters", lambda lid: _rosters_with_actionable_lineups()
+    )
+    monkeypatch.setattr(
+        h,
+        "get_sleeper_league_users",
+        lambda lid: [
+            {"user_id": ADMIN_ID, "display_name": "Admin"},
+            {"user_id": "user-1", "display_name": "U1"},
+            {"user_id": "user-2", "display_name": "U2"},
+        ],
+    )
+    monkeypatch.setattr(
+        h, "fetch_nfl_players", lambda: {"P_OUT": {"injury_status": "Out"}}
+    )
+    monkeypatch.setattr(
+        h, "get_nfl_state", lambda: {"week": 4, "season": "2026"}
+    )
+    monkeypatch.setattr(h, "send_push_to_users", _send_push_to_users)
+    monkeypatch.setattr(h, "send_emails_concurrently", _send_emails)
+
+    return state
+
+
+class TestDisabledShortCircuit:
+    def test_disabled_returns_skipped(self, patched) -> None:
+        from lambdas.notif_lineup_not_set.handler import handler
+
+        patched["cron_setting"]["enabled"] = False
+        response = handler({}, context=None)
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert body["skipped"] is True
+        assert patched["send_push_calls"] == []
+
+
+class TestTestModeFiltering:
+    def test_test_mode_filters_to_admin_only(self, patched) -> None:
+        from lambdas.notif_lineup_not_set.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        handler({}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert recipients == {ADMIN_ID}
+
+
+class TestDefaultPassthrough:
+    def test_default_settings_unfiltered_fan_out(self, patched) -> None:
+        from lambdas.notif_lineup_not_set.handler import handler
+
+        handler({}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert ADMIN_ID in recipients
+        assert "user-1" in recipients
+        assert "user-2" in recipients

--- a/tests/test_notif_weekly_recap_settings_gate.py
+++ b/tests/test_notif_weekly_recap_settings_gate.py
@@ -1,0 +1,178 @@
+"""
+Tests for the admin-cron-settings gate inside `notif_weekly_recap`.
+
+Covers:
+  - enabled=False short-circuits before any data fetch + send.
+  - test_mode=True restricts recipient list to admin only.
+  - Default (enabled=True, test_mode=False) preserves the existing
+    behavior (whitelisted_users passed through unfiltered).
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _admin_row() -> dict[str, Any]:
+    return {
+        "id": "row-admin",
+        "sleeper_user_id": ADMIN_ID,
+        "email": "admin@example.com",
+        "display_name": "Admin",
+        "is_active": True,
+        "is_admin": True,
+    }
+
+
+def _other_user(idx: int) -> dict[str, Any]:
+    return {
+        "id": f"row-u{idx}",
+        "sleeper_user_id": f"user-{idx}",
+        "email": f"user{idx}@example.com",
+        "display_name": f"User {idx}",
+        "is_active": True,
+        "is_admin": False,
+    }
+
+
+def _matchup_pair(matchup_id: int, roster_a: int, roster_b: int) -> list[dict[str, Any]]:
+    return [
+        {"matchup_id": matchup_id, "roster_id": roster_a, "points": 110.0},
+        {"matchup_id": matchup_id, "roster_id": roster_b, "points": 95.0},
+    ]
+
+
+def _rosters() -> list[dict[str, Any]]:
+    """Each roster's owner_id matches a user in the whitelisted list
+    so the recipient resolution path is exercised."""
+    return [
+        {"roster_id": 1, "owner_id": ADMIN_ID, "starters": []},
+        {"roster_id": 2, "owner_id": "user-1", "starters": []},
+        {"roster_id": 3, "owner_id": "user-2", "starters": []},
+        {"roster_id": 4, "owner_id": "user-3", "starters": []},
+    ]
+
+
+def _users() -> list[dict[str, Any]]:
+    """Sleeper league users list (matches owner_id values in _rosters)."""
+    return [
+        {"user_id": ADMIN_ID, "display_name": "Admin", "metadata": {"team_name": "Admins"}},
+        {"user_id": "user-1", "display_name": "U1", "metadata": {"team_name": "Ones"}},
+        {"user_id": "user-2", "display_name": "U2", "metadata": {"team_name": "Twos"}},
+        {"user_id": "user-3", "display_name": "U3", "metadata": {"team_name": "Threes"}},
+    ]
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.notif_weekly_recap import handler as h
+
+    state: dict[str, Any] = {
+        "cron_setting": {
+            "cron_key": "notif_weekly_recap",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Weekly recap",
+        },
+        "league_row": {"league_id": "L1", "league_name": "Test League"},
+        "whitelisted": [_admin_row(), _other_user(1), _other_user(2), _other_user(3)],
+        "rosters": _rosters(),
+        "users": _users(),
+        "nfl_state": {"week": 5, "season": "2026", "season_type": "regular"},
+        "matchups": _matchup_pair(1, 1, 2) + _matchup_pair(2, 3, 4),
+        "send_push_calls": [],
+        "send_email_call": None,
+    }
+
+    def _get_cron_setting(cron_key: str):
+        return dict(state["cron_setting"])
+
+    def _send_push_to_users(user_ids, title, body, category, data):
+        state["send_push_calls"].append(
+            {"user_ids": list(user_ids), "title": title}
+        )
+
+    def _send_emails(tasks):
+        state["send_email_call"] = list(tasks)
+        return (len(tasks), 0)
+
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(h, "get_active_whitelisted_league", lambda: state["league_row"])
+    monkeypatch.setattr(
+        h, "get_active_whitelisted_users", lambda: list(state["whitelisted"])
+    )
+    monkeypatch.setattr(h, "get_sleeper_league_rosters", lambda lid: state["rosters"])
+    monkeypatch.setattr(h, "get_sleeper_league_users", lambda lid: state["users"])
+    monkeypatch.setattr(
+        h, "get_sleeper_league_matchups", lambda lid, week: state["matchups"]
+    )
+    monkeypatch.setattr(h, "get_nfl_state", lambda: state["nfl_state"])
+    monkeypatch.setattr(h, "send_push_to_users", _send_push_to_users)
+    monkeypatch.setattr(h, "send_emails_concurrently", _send_emails)
+
+    return state
+
+
+class TestDisabledShortCircuit:
+    def test_disabled_returns_skipped(self, patched) -> None:
+        from lambdas.notif_weekly_recap.handler import handler
+
+        patched["cron_setting"]["enabled"] = False
+        response = handler({}, context=None)
+
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert body["skipped"] is True
+        assert body["reason"] == "disabled"
+        # No data fetch / send happened.
+        assert patched["send_push_calls"] == []
+        assert patched["send_email_call"] is None
+
+
+class TestTestModeFiltering:
+    def test_test_mode_filters_to_admin_only(self, patched) -> None:
+        from lambdas.notif_weekly_recap.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        handler({}, context=None)
+
+        # Only the admin's roster (owner_id=ADMIN_ID) should receive pushes.
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert recipients == {ADMIN_ID}
+
+    def test_test_mode_with_no_admin_in_list_sends_nothing(self, patched) -> None:
+        """If the admin row is missing from whitelisted_users, test
+        mode must produce zero sends (defensive behaviour)."""
+        from lambdas.notif_weekly_recap.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        patched["whitelisted"] = [_other_user(1), _other_user(2)]
+
+        handler({}, context=None)
+        assert patched["send_push_calls"] == []
+
+
+class TestDefaultPassthrough:
+    def test_default_settings_unfiltered_fan_out(self, patched) -> None:
+        from lambdas.notif_weekly_recap.handler import handler
+
+        handler({}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        # All 4 managers should be in the push set.
+        assert ADMIN_ID in recipients
+        assert "user-1" in recipients
+        assert "user-2" in recipients
+        assert "user-3" in recipients

--- a/tests/test_notif_worldcup_movement_settings_gate.py
+++ b/tests/test_notif_worldcup_movement_settings_gate.py
@@ -1,0 +1,126 @@
+"""
+Tests for the admin-cron-settings gate inside `notif_worldcup_movement`.
+
+Covers:
+  - enabled=False short-circuits before any data fetch + send.
+  - test_mode=True restricts recipient list to admin only.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+ADMIN_ID = "594625531702460416"
+
+
+def _user_row(sleeper_id: str, *, idx: int) -> dict[str, Any]:
+    return {
+        "sleeper_user_id": sleeper_id,
+        "email": f"u{idx}@example.com",
+        "is_active": True,
+        "is_admin": sleeper_id == ADMIN_ID,
+    }
+
+
+@pytest.fixture
+def patched(monkeypatch: pytest.MonkeyPatch):
+    from lambdas.notif_worldcup_movement import handler as h
+
+    state: dict[str, Any] = {
+        "cron_setting": {
+            "cron_key": "notif_worldcup_movement",
+            "enabled": True,
+            "test_mode": False,
+            "description": "Worldcup",
+        },
+        "whitelisted": [_user_row(ADMIN_ID, idx=0), _user_row("user-1", idx=1)],
+        "send_push_calls": [],
+        # Simulated transitions: both users clinched their division.
+        "transitions": [
+            {"user_id": ADMIN_ID, "kind": "status", "to": "clinched", "division": 1},
+            {"user_id": "user-1", "kind": "status", "to": "clinched", "division": 2},
+        ],
+        "league_row": {
+            "league_id": "L1",
+            "has_taxi": True,
+            "is_dynasty": True,
+            "season": "2026",
+        },
+    }
+
+    def _get_cron_setting(cron_key: str):
+        return dict(state["cron_setting"])
+
+    def _send_push_to_users(user_ids, title, body, category, data):
+        state["send_push_calls"].append({"user_ids": list(user_ids)})
+
+    # The worldcup handler does a LOT of helper invocation — stub the
+    # internals it uses so the test focuses only on the gate logic.
+    monkeypatch.setattr(h, "get_cron_setting", _get_cron_setting)
+    monkeypatch.setattr(h, "get_active_whitelisted_league", lambda: state["league_row"])
+    monkeypatch.setattr(
+        h, "get_active_whitelisted_users", lambda: list(state["whitelisted"])
+    )
+    monkeypatch.setattr(h, "send_push_to_users", _send_push_to_users)
+
+    # Replace the chain + standings + diff pipeline with deterministic
+    # stubs so we test only the gate + recipient filter.
+    monkeypatch.setattr(
+        h,
+        "get_league_chain",
+        lambda head_id, fetch_league_fn=None: [
+            {"league_id": "L1", "status": "in_season", "season": "2026"},
+        ],
+    )
+    monkeypatch.setattr(h, "_gather_chain_matchups", lambda chain: [])
+    monkeypatch.setattr(h, "compute_division_standings", lambda matchups, names: [])
+    monkeypatch.setattr(h, "clinch_for_division", lambda teams, games_remaining=6: None)
+    monkeypatch.setattr(h, "status_map_from_standings", lambda standings: {})
+    monkeypatch.setattr(h, "diff_snapshots", lambda current, prev: state["transitions"])
+    monkeypatch.setattr(h, "_read_snapshot", lambda lid, season, week: {})
+    monkeypatch.setattr(h, "_write_snapshot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(h, "division_name_map_from_league", lambda league: {1: "AFC", 2: "NFC"})
+
+    return state
+
+
+class TestDisabledShortCircuit:
+    def test_disabled_returns_skipped(self, patched) -> None:
+        from lambdas.notif_worldcup_movement.handler import handler
+
+        patched["cron_setting"]["enabled"] = False
+        response = handler({}, context=None)
+        assert response["statusCode"] == 200
+        body = response["body"]
+        assert body["skipped"] is True
+        assert patched["send_push_calls"] == []
+
+
+class TestTestModeFiltering:
+    def test_test_mode_filters_to_admin_only(self, patched) -> None:
+        from lambdas.notif_worldcup_movement.handler import handler
+
+        patched["cron_setting"]["test_mode"] = True
+        handler({"week": 5}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert recipients == {ADMIN_ID}
+
+
+class TestDefaultPassthrough:
+    def test_default_unfiltered_fan_out(self, patched) -> None:
+        from lambdas.notif_worldcup_movement.handler import handler
+
+        handler({"week": 5}, context=None)
+        recipients = {
+            uid
+            for call in patched["send_push_calls"]
+            for uid in call["user_ids"]
+        }
+        assert ADMIN_ID in recipients
+        assert "user-1" in recipients


### PR DESCRIPTION
## Summary

Adds per-lambda kill switch (`enabled`) and test-mode (`test_mode`) flags for all five scheduled notif lambdas. Backed by a new `admin_cron_settings` Supabase table, two new admin-gated API endpoints, and lambda-side wraps.

- **Kill switch**: when `enabled=false`, the lambda short-circuits before any data fetch — useful as a safety belt against the offseason guard.
- **Test mode**: when `test_mode=true`, recipient delivery is restricted to admin (Dominick) only — lets us preview AI Review newsletters + recap emails before fanning out to the league.
- **Single helper, shared filter**: `lambdas/common/cron_settings.py` (best-effort reads) + `lambdas/common/admin_only_filter.py` (one filter for all five lambdas → no drift risk).
- **Best-effort reads**: a Supabase outage during cron fire defaults the lambda to `enabled=True, test_mode=False`. The offseason guard remains the primary safety; an outage MUST NOT silently skip a send.

Plan: `xomper-ios/docs/features/admin-cron-settings/PLAN.md` (Ready).

## Endpoints added

- `GET  /admin/cron-settings-list`   — admin-gated, returns all 5 rows + `table_missing` flag for graceful empty state.
- `POST /admin/cron-settings-update` — admin-gated, body `{ cron_key, enabled?, test_mode? }`, writes `admin_audit` row with `action=cron_settings.update`.

## Lambdas modified

- `notif_weekly_recap`, `notif_lineup_not_set`, `notif_close_game_alert`, `notif_worldcup_movement` — gate + filter `whitelisted_users` to admin only when `test_mode=true`.
- `notif_ai_review_weekly` — gate + forwards `test_mode → dry_run=True` to the F3 orchestrator (reuses existing admin-only delivery path).

## Dependencies

- **Infra PR #114** — adds the two new API GW routes (`admin-cron-settings-list` GET + `admin-cron-settings-update` POST). This PR cannot be reached over HTTPS until #114 merges + applies.
- **Manual Supabase migration** — run `sql/admin_cron_settings_migration.sql` via the Supabase dashboard SQL editor (same pattern as F4's `admin_audit`). The migration is idempotent (`on conflict do nothing`) and seeds 5 rows.

## Test plan

- [x] `pytest tests/` — 549 tests pass (492 baseline + 57 new)
- [x] Helper happy path + Supabase-failure best-effort + table_missing graceful fallback
- [x] Endpoint admin gate, validation, audit-row assertion
- [x] Per-lambda integration: skip-on-disabled + admin-only-on-test-mode
- [x] AI Review weekly: test_mode forces dry_run=True even when event passes dry_run=False

## Post-merge verification

- [ ] Apply migration in Supabase dashboard, confirm 5 rows seeded
- [ ] Hit `/admin/cron-settings-list` from admin client, confirm 5 rows returned
- [ ] Toggle `notif_ai_review_weekly` test_mode=true, wait for next Tue 2pm cron, confirm only admin receives email
- [ ] Toggle back to false before next league-wide send
- [ ] Verify `admin_audit` rows show up per toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)