### PR TITLE
fix(authorizer): verify Supabase ES256 JWTs via JWKS

### DIFF
--- a/lambdas/authorizer/handler.py
+++ b/lambdas/authorizer/handler.py
@@ -1,17 +1,35 @@
 """
 Lambda Authorizer
 =================
-JWT-based API Gateway authorizer for Xomper.
+API Gateway authorizer for Xomper. Verifies Supabase access tokens
+signed with ES256 via the project's published JWKS.
+
+Supabase JWTs use ES256 (ECDSA P-256) signed with a project-scoped
+key pair. Public keys are published at
+`{SUPABASE_URL}/auth/v1/.well-known/jwks.json`. PyJWKClient fetches +
+caches them at module load, so verification on each invocation is a
+local signature check.
 """
 
+import os
+
 import jwt
+from jwt import PyJWKClient
+
 from lambdas.common.constants import PRODUCT
-from lambdas.common.ssm_helpers import API_SECRET_KEY
 from lambdas.common.logger import get_logger
 
 log = get_logger(__file__)
 
 HANDLER = 'authorizer'
+
+# Module-level so PyJWKClient's internal key cache survives across
+# Lambda warm invocations.
+_SUPABASE_URL = (os.environ.get('SUPABASE_URL') or '').rstrip('/')
+_JWKS_URL = f"{_SUPABASE_URL}/auth/v1/.well-known/jwks.json" if _SUPABASE_URL else ''
+_jwks_client: PyJWKClient | None = (
+    PyJWKClient(_JWKS_URL, cache_keys=True) if _JWKS_URL else None
+)
 
 
 def generate_policy(effect: str, resource: str) -> dict:
@@ -32,15 +50,29 @@ def generate_policy(effect: str, resource: str) -> dict:
 
 
 def decode_auth_token(auth_token: str) -> dict | None:
-    """Decode a JWT auth token. Returns claims dict or None on failure."""
+    """Decode + verify a Supabase JWT. Returns claims dict or None on
+    any failure (expired, bad signature, missing key, etc.)."""
+    if _jwks_client is None:
+        log.error("Authorizer: SUPABASE_URL env var missing — cannot verify tokens")
+        return None
     try:
-        token = auth_token.replace('Bearer ', '')
-        return jwt.decode(token, API_SECRET_KEY, algorithms=['HS256'])
+        token = auth_token.replace('Bearer ', '').strip()
+        signing_key = _jwks_client.get_signing_key_from_jwt(token)
+        return jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=['ES256'],
+            audience='authenticated',
+        )
     except jwt.ExpiredSignatureError:
         log.warning("Authorizer: token expired")
         return None
     except jwt.InvalidTokenError as err:
         log.warning(f"Authorizer: invalid token - {err}")
+        return None
+    except Exception as err:
+        # Network failures fetching JWKS, malformed token header, etc.
+        log.warning(f"Authorizer: decode error - {err}")
         return None
 
 


### PR DESCRIPTION
Pairs with the xomper-infrastructure PR exposing `SUPABASE_URL` as a Lambda env var.

## Root cause
Supabase signs JWTs with **ES256** (curl-confirmed at the project JWKS endpoint). The current handler verifies with `algorithms=['HS256']` and secret "xomper". Every real Supabase token failed with `The specified alg value is not allowed` — surfaced to iOS as 403 on Audit, Tables, Test Email, Logs, Announcements, AI report reads, etc.

## Fix
- Module-level `PyJWKClient` fetches + caches `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`
- Per-call: pick signing key by JWT `kid`, verify ES256 signature + `audience="authenticated"`
- Drop the unused `API_SECRET_KEY` import

## Deploy order
Merge xomper-infrastructure PR **first** so `SUPABASE_URL` env var lands, then this. Reverse order: new handler can't find the URL → denies everything.

## Test plan
- [ ] CI deploys clean
- [ ] `curl -H 'Authorization: Bearer <real-supabase-jwt>' https://api.xomper.xomware.com/ai-reports/list?limit=1` returns 200
- [ ] iOS Admin → Audit / Tables / Test Email load real data on v2.31.3 (no app rebuild)