### PR TITLE
chore: upgrade Python runtime 3.10 -> 3.13 across backend

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -31,8 +31,10 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
-          # Check if common layer changed
-          if echo "$CHANGED_FILES" | grep -q "^lambdas/common/"; then
+          # Check if common layer changed. requirements.txt also forces
+          # a layer rebuild — bumping a dep wouldn't otherwise produce a
+          # new layer version.
+          if echo "$CHANGED_FILES" | grep -qE "^(lambdas/common/|requirements\.txt$)"; then
             echo "common=true" >> $GITHUB_OUTPUT
           else
             echo "common=false" >> $GITHUB_OUTPUT
@@ -71,7 +73,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -104,7 +106,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |
@@ -134,13 +136,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Package layer
         run: |
           mkdir -p python/lambdas
           cp -r lambdas/common python/lambdas/
-          python3.10 -m pip install --platform manylinux2014_x86_64 --only-binary=:all: -t python/ -r requirements.txt
+          python3.13 -m pip install --platform manylinux2014_x86_64 --only-binary=:all: -t python/ -r requirements.txt
           zip -r xomper-shared-packages.zip python
 
       - name: Deploy layer
@@ -152,7 +154,7 @@ jobs:
           LAYER_OUTPUT=$(aws lambda publish-layer-version \
             --layer-name xomper-shared-packages \
             --zip-file fileb://xomper-shared-packages.zip \
-            --compatible-runtimes python3.10 \
+            --compatible-runtimes python3.13 \
             --region $AWS_REGION \
             --output json)
 
@@ -199,7 +201,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Package lambda
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-# Python 3.10
+# Python 3.13
 annotated-types==0.7.0
 anthropic==0.50.0
-cffi==1.16.0
+cffi==1.17.1
 charset-normalizer==3.3.2
 cryptography==42.0.8
 idna==3.7


### PR DESCRIPTION
## Summary
- Bump `cffi` 1.16.0 -> 1.17.1 (1.16 has no cp313 wheel; 1.17 does)
- Update all workflow `python-version` pins to 3.13
- Layer publish: `--compatible-runtimes python3.13`
- detect-changes: treat `requirements.txt` edits as common-changing so dep bumps actually rebuild the layer

## Pairs with
xomper-infrastructure PR removing the temporary `python3.10` pin on the authorizer.

## Why
The authorizer needs `cryptography` for ES256 (Supabase JWT verification). The 3.10-built shared layer's cp310 cffi extension can't load on python3.13, so we'd pinned the authorizer to 3.10 as a stopgap. Bumping the layer to 3.13 lets the authorizer run on the same runtime as everything else.