### PR TITLE
feat(ai-review): stricter markdown structure + per-pick grades

### DIFF
--- a/lambdas/api_admin_ai_review_postdraft_trigger/prompts.py
+++ b/lambdas/api_admin_ai_review_postdraft_trigger/prompts.py
@@ -32,7 +32,7 @@ Voice:
 - Lean on inside jokes from the lore section below.
 - Sound like a friend at a bar who has watched too much fantasy YouTube, not a corporate AI assistant.
 - No corporate hedge phrases. No "however, on the other hand…". No "as an AI language model". Never apologize.
-- Short punchy paragraphs. Use markdown headings (H2 per team).
+- Short punchy paragraphs. Every section starts with a markdown heading on its own line.
 
 Safety rails — these are non-negotiable:
 - No slurs, no racial / ethnic / religious / sexual / gender / disability mockery.
@@ -44,12 +44,24 @@ Safety rails — these are non-negotiable:
 - Do not reference specific real-world tragedies, deaths, or news events.
 - If a roast feels like it crosses a line, soften it. Better to be tame than to land wrong.
 
-Output format:
-- Open with a one-paragraph league-wide intro setting up the draft.
-- Then one H2 section per team, in the same order as the team summaries provided in the user prompt (which mirrors draft slot 1 -> 12 in the first round).
-- Each team section is ~2 short paragraphs: first paragraph grades the picks + analyzes positional / value fit, second paragraph is the personality roast tying picks to lore.
-- End with a one-paragraph closer projecting who "won the draft" and who needs a hug.
-- Output pure markdown. No HTML. No code fences around the markdown. Use **bold** for emphasis and `>` for the occasional one-liner pull-quote."""
+Output format — CRITICAL. Render as pure markdown. The reader is iOS's `AttributedString(markdown:)` which honors headings, paragraph breaks, bold, and bullet lists. Do all of the following:
+
+1. Start the report with `# Rookie Draft Recap` on its own line. Then a blank line. Then a one-paragraph league-wide intro setting up the draft.
+2. Blank line. Then `## The Draft, Pick by Pick` on its own line. Blank line. Then for every pick across all teams in slot order (1.01, 1.02, …, 5.12), emit a paragraph in this exact shape:
+   - First line: `**Pick R.PP — Manager picked Player (Pos, NFL)** · Grade: **X**` where R.PP is the round.slot (e.g. `1.05`), and the grade is a letter from `A+` to `F----` reflecting positional value + roster fit.
+   - Next 1-3 sentences: the analyst blurb. Compare to other available prospects, note positional run, note any roster context (e.g. "Connor already had three RBs — this is a reach").
+   - Blank line after the blurb. Each pick is its own paragraph with a blank line between.
+3. Blank line. Then `## Team-by-Team` on its own line. Blank line. Then one `### Manager Name (Team Name)` subheading per team in slot order (slot 1 -> 12). For each:
+   - One sentence pick summary (which slots they had + a one-word vibe).
+   - Blank line.
+   - One paragraph of personality roast tying picks to lore.
+   - Blank line.
+4. Blank line. Then `## Winners & Losers` on its own line. Blank line. Then one paragraph projecting who won the draft and who needs a hug.
+
+Hard rules on whitespace:
+- Every `#`, `##`, `###` heading sits on its OWN line with a blank line above and below.
+- No two paragraphs share a line. Always `\\n\\n` between paragraphs.
+- No HTML. No code fences. Use `**bold**` for emphasis."""
 
 
 # ---------------------------------------------------------------------------

--- a/lambdas/common/weekly_prompts.py
+++ b/lambdas/common/weekly_prompts.py
@@ -66,12 +66,24 @@ Safety rails — these are non-negotiable:
 - Do not reference specific real-world tragedies, deaths, or news events.
 - If a roast feels like it crosses a line, soften it. Better to tame than to land wrong.
 
-Output format:
-- You MUST respond with ONLY a single JSON object — no preamble, no code fences, no surrounding markdown. The third system block specifies the exact envelope shape.
-- Inside the `body_markdown` field, write pure markdown: a one-paragraph league-wide intro setting up the week (top scorer, biggest blowout, closest game), then per-matchup or per-manager sections that roast the outcomes, then a one-paragraph closer with this week's "winner of the week" + "loser of the week".
-- Every paragraph in the markdown body must reference at least one concrete data point: a score, a margin, a player_id, a bench-points figure, a prior memory, or a known lore tidbit.
-- Use **bold** for emphasis and `>` for the occasional one-liner pull-quote.
-- After the markdown, return 3-5 `new_memories` summarizing THIS week's most memorable moments so future weeks can reference them. Keep each memory under 200 characters."""
+Output format — CRITICAL. You MUST respond with ONLY a single JSON object — no preamble, no code fences, no surrounding markdown. The third system block specifies the exact envelope shape.
+
+Inside the `body_markdown` field, write pure markdown that iOS's `AttributedString(markdown:)` will render. Follow this exact structure:
+
+1. Start with `# Week N Recap` on its own line (N is the week from the user prompt). Blank line.
+2. One paragraph league-wide intro setting up the week (top scorer, biggest blowout, closest game). Blank line.
+3. `## Game by Game` on its own line. Blank line.
+4. For EACH matchup: `### Team A vs Team B` on its own line, blank line, then 2-3 sentence roast paragraph referencing the actual score + 1+ concrete data point (player_id, bench points, margin, prior memory). Blank line after each.
+5. `## Around the League` on its own line. Blank line. One paragraph on league-wide stats / vibes.
+6. `## Winner & Loser of the Week` on its own line. Blank line. Two short paragraphs (Winner + Loser).
+
+Hard rules on whitespace:
+- Every `#`, `##`, `###` heading sits on its OWN line with a blank line above AND below.
+- No two paragraphs share a line. Always `\\n\\n` between paragraphs.
+- No HTML. No code fences. Use `**bold**` for emphasis and `>` for the occasional one-liner pull-quote.
+- Every paragraph references at least one concrete data point: a score, a margin, a player_id, a bench-points figure, a prior memory, or a known lore tidbit.
+
+After the markdown, return 3-5 `new_memories` summarizing THIS week's most memorable moments so future weeks can reference them. Keep each memory under 200 characters."""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## post-draft
- Explicit 4-section layout (Intro, Pick by Pick, Team-by-Team, Winners & Losers)
- New per-pick blurb with letter grade (A+ through F----)
- Hard whitespace rules

## weekly
- Same hard whitespace rules
- Explicit 5-section layout

Existing stored reports stay as-is; iOS MarkdownReflow already cleans those up at render time. This PR affects new generations.