### PR TITLE
feat(weekly-recap): standings + playoff bracket + World Cup sections

### DIFF
--- a/lambdas/api_admin_email_test_template/handler.py
+++ b/lambdas/api_admin_email_test_template/handler.py
@@ -70,11 +70,13 @@ _LEAGUE_NAME = "CLT DYNASTY"
 # and offseason-safe.
 _FIXTURES: dict[str, dict[str, Any]] = {
     "weekly_recap": {
-        "subject": f"[TEST] Week 17 {_LEAGUE_NAME} recap",
+        "subject": f"[TEST] Week 14 {_LEAGUE_NAME} recap",
         "params": {
             "manager_name": "Dom",
             "league_name": _LEAGUE_NAME,
-            "week": 17,
+            # Week 14 = first playoff week — exercises both standings
+            # AND bracket sections in the sample.
+            "week": 14,
             "user_team_name": "Nvr 4get Da CLT",
             "user_points": 124.5,
             "opponent_team_name": "ktatich",
@@ -96,6 +98,72 @@ _FIXTURES: dict[str, dict[str, Any]] = {
                 ("gniadek", 88.7),
                 ("reesegriffin", 81.0),
                 ("Nico Suave", 72.1),
+            ],
+            # Cumulative standings — (team, wins, losses, ties, points_for).
+            "standings": [
+                ("Gangsters of Love",      11, 3, 0, 1763.4),
+                ("Nvr 4get Da CLT",        10, 4, 0, 1702.1),
+                ("ktatich",                 9, 5, 0, 1690.5),
+                ("The Goffather",           9, 5, 0, 1652.3),
+                ("Wake Forest Factory",     8, 6, 0, 1641.0),
+                ("Brock Party",             7, 7, 0, 1598.8),
+                ("Shits and Gibbles",       6, 8, 0, 1554.2),
+                ("Sinnott Committee",       6, 8, 0, 1521.7),
+                ("Shane Beamer's Burner",   5, 9, 0, 1502.0),
+                ("gniadek",                 4, 10, 0, 1480.4),
+                ("reesegriffin",            3, 11, 0, 1421.6),
+                ("Nico Suave",              2, 12, 0, 1380.9),
+            ],
+            # Playoff bracket — list of (round_label, [(team_a, score_a,
+            # team_b, score_b)]). None scores mean upcoming.
+            "bracket_rounds": [
+                ("Quarterfinals", [
+                    ("Gangsters of Love",   162.6, "Nico Suave",              72.1),
+                    ("Nvr 4get Da CLT",     124.5, "ktatich",                 102.3),
+                    ("The Goffather",       113.0, "Wake Forest Factory",     111.5),
+                    ("Brock Party",         105.9, "Shane Beamer's Burner",   89.6),
+                ]),
+                ("Semifinals", [
+                    ("Gangsters of Love",   None,  "Brock Party",             None),
+                    ("Nvr 4get Da CLT",     None,  "The Goffather",           None),
+                ]),
+                ("Championship", [
+                    ("TBD",                 None,  "TBD",                     None),
+                ]),
+            ],
+            # Personal World Cup snapshot for the recipient.
+            "wc_personal": {
+                "division": "East Division",
+                "position": 2,
+                "status": "clinched",
+                "wins": 7,
+                "losses": 4,
+                "ties": 0,
+                "points_for": 1284.3,
+                "points_back": None,
+            },
+            # Full WC standings by division, top-2 clinched.
+            "wc_divisions": [
+                ("East Division", [
+                    {"team_name": "Gangsters of Love",   "wins": 9, "losses": 2, "ties": 0, "points_for": 1422.0, "status": "clinched", "is_user": False},
+                    {"team_name": "Nvr 4get Da CLT",     "wins": 7, "losses": 4, "ties": 0, "points_for": 1284.3, "status": "clinched", "is_user": True},
+                    {"team_name": "Shits and Gibbles",   "wins": 4, "losses": 7, "ties": 0, "points_for": 1188.5, "status": "eliminated", "is_user": False},
+                ]),
+                ("West Division", [
+                    {"team_name": "ktatich",             "wins": 8, "losses": 3, "ties": 0, "points_for": 1351.2, "status": "clinched", "is_user": False},
+                    {"team_name": "The Goffather",       "wins": 7, "losses": 4, "ties": 0, "points_for": 1297.8, "status": "alive",    "is_user": False},
+                    {"team_name": "reesegriffin",        "wins": 2, "losses": 9, "ties": 0, "points_for": 1098.6, "status": "eliminated", "is_user": False},
+                ]),
+                ("North Division", [
+                    {"team_name": "Wake Forest Factory", "wins": 7, "losses": 4, "ties": 0, "points_for": 1306.4, "status": "clinched", "is_user": False},
+                    {"team_name": "Brock Party",         "wins": 6, "losses": 5, "ties": 0, "points_for": 1241.9, "status": "alive",    "is_user": False},
+                    {"team_name": "gniadek",             "wins": 3, "losses": 8, "ties": 0, "points_for": 1142.7, "status": "alive",    "is_user": False},
+                ]),
+                ("South Division", [
+                    {"team_name": "Sinnott Committee",   "wins": 6, "losses": 5, "ties": 0, "points_for": 1230.5, "status": "alive",    "is_user": False},
+                    {"team_name": "Shane Beamer's Burner","wins": 5, "losses": 6, "ties": 0, "points_for": 1198.0, "status": "alive",    "is_user": False},
+                    {"team_name": "Nico Suave",          "wins": 1, "losses": 10, "ties": 0, "points_for": 1054.1, "status": "eliminated", "is_user": False},
+                ]),
             ],
         },
     },

--- a/lambdas/common/email_templates/weekly_recap.py
+++ b/lambdas/common/email_templates/weekly_recap.py
@@ -30,11 +30,33 @@ def generate_weekly_recap_email(
     league_high_team: str,
     league_high_points: float,
     all_scores: list[tuple[str, float]],
+    standings: list[tuple[str, int, int, int, float]] | None = None,
+    bracket_rounds: list[tuple[str, list[tuple[str, float, str, float]]]] | None = None,
+    wc_personal: dict | None = None,
+    wc_divisions: list[tuple[str, list[dict]]] | None = None,
 ) -> str:
     """Generate HTML email for weekly recap.
 
-    `all_scores` is a list of (team_name, points) sorted desc. Renders
-    as the league standings table at the bottom of the recap.
+    `all_scores` is a list of (team_name, points) sorted desc — renders
+    as the THIS WEEK scoreboard.
+
+    `standings` is the cumulative season table, list of
+    (team_name, wins, losses, ties, points_for) sorted in ranking order.
+    Rendered always when present.
+
+    `bracket_rounds` is the playoff bracket as
+    (round_label, [(team_a, score_a, team_b, score_b)]) per round.
+    Only rendered when week >= 12 AND non-empty.
+
+    `wc_personal` (optional) is the recipient's World Cup standing —
+    keys: `division`, `position` (1..N), `status` (clinched|alive|
+    eliminated), `wins`, `points_for`, `points_back` (vs cutoff, None
+    if clinched or N/A).
+
+    `wc_divisions` (optional) is the full World Cup standings table
+    grouped by division — list of (division_name, [team_dict]) where
+    each team_dict has keys: `team_name`, `wins`, `losses`, `ties`,
+    `points_for`, `status`, `is_user`.
     """
     safe_manager = _escape(manager_name)
     safe_team = _escape(user_team_name)
@@ -75,6 +97,10 @@ def generate_weekly_recap_email(
         </tr>
         """
 
+    standings_html = _standings_section(standings, user_team_name) if standings else ""
+    bracket_html = _bracket_section(bracket_rounds) if (bracket_rounds and week >= 12) else ""
+    wc_html = _worldcup_section(wc_personal, wc_divisions) if (wc_personal or wc_divisions) else ""
+
     content = f"""
     {generate_section_title(f"Week {week} Recap")}
     {generate_league_badge(league_name) if league_name else ""}
@@ -97,7 +123,9 @@ def generate_weekly_recap_email(
         </tr>
     </table>
 
-    <!-- Standings table -->
+    {_section_header("This week's scores")}
+
+    <!-- This week's scoreboard -->
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
             <td style="padding: 0 24px 16px;">
@@ -119,6 +147,10 @@ def generate_weekly_recap_email(
             </td>
         </tr>
     </table>
+
+    {standings_html}
+    {bracket_html}
+    {wc_html}
 
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
@@ -146,18 +178,291 @@ def generate_weekly_recap_email_plain_text(
     league_high_team: str,
     league_high_points: float,
     all_scores: list[tuple[str, float]],
+    standings: list[tuple[str, int, int, int, float]] | None = None,
+    bracket_rounds: list[tuple[str, list[tuple[str, float, str, float]]]] | None = None,
+    wc_personal: dict | None = None,
+    wc_divisions: list[tuple[str, list[dict]]] | None = None,
 ) -> str:
     if is_tie:
         result = "Tied"
     else:
         result = "Won" if user_won else "Lost"
-    table_lines = [f"{i + 1}. {team}: {pts:.2f}" for i, (team, pts) in enumerate(all_scores)]
-    return (
-        f"Hey {manager_name},\n\n"
-        f"Week {week} {league_name} recap.\n\n"
+    score_lines = [f"{i + 1}. {team}: {pts:.2f}" for i, (team, pts) in enumerate(all_scores)]
+
+    parts: list[str] = [
+        f"Hey {manager_name},",
+        "",
+        f"Week {week} {league_name} recap.",
+        "",
         f"{result}: {user_team_name} {user_points:.2f} vs "
-        f"{opponent_team_name} {opponent_points:.2f}\n"
-        f"League high: {league_high_team} ({league_high_points:.2f})\n\n"
-        f"Standings:\n" + "\n".join(table_lines) + "\n\n"
-        f"Open Xomper: {XOMPER_URL}\n"
-    )
+        f"{opponent_team_name} {opponent_points:.2f}",
+        f"League high: {league_high_team} ({league_high_points:.2f})",
+        "",
+        "This week's scores:",
+        *score_lines,
+    ]
+
+    if standings:
+        parts.append("")
+        parts.append("Standings (cumulative):")
+        for i, (team, w, l, t, pf) in enumerate(standings):
+            record = f"{w}-{l}-{t}" if t else f"{w}-{l}"
+            parts.append(f"{i + 1}. {team}: {record}, {pf:.1f} PF")
+
+    if bracket_rounds and week >= 12:
+        parts.append("")
+        parts.append("Playoff bracket:")
+        for round_label, pairs in bracket_rounds:
+            parts.append(f"  {round_label}")
+            for a, sa, b, sb in pairs:
+                if sa is not None and sb is not None:
+                    parts.append(f"    {a} {sa:.1f} vs {b} {sb:.1f}")
+                else:
+                    parts.append(f"    {a} vs {b}")
+
+    if wc_personal:
+        parts.append("")
+        parts.append("World Cup:")
+        div = wc_personal.get("division") or ""
+        pos = wc_personal.get("position") or "?"
+        status = wc_personal.get("status") or "alive"
+        wins = wc_personal.get("wins")
+        pf = wc_personal.get("points_for")
+        line = f"  You are #{pos} in {div} — {status}"
+        if wins is not None and pf is not None:
+            line += f" ({wins} divisional wins, {pf:.1f} PF)"
+        parts.append(line)
+        pb = wc_personal.get("points_back")
+        if pb is not None:
+            parts.append(f"  {pb:.1f} pts back from a qualifying spot")
+
+    if wc_divisions:
+        parts.append("")
+        parts.append("Full World Cup standings:")
+        for div_name, teams in wc_divisions:
+            parts.append(f"  {div_name}")
+            for t in teams:
+                marker = "  ← you" if t.get("is_user") else ""
+                w = t.get("wins", 0)
+                l = t.get("losses", 0)
+                tie = t.get("ties", 0)
+                record = f"{w}-{l}-{tie}" if tie else f"{w}-{l}"
+                parts.append(
+                    f"    {t.get('team_name','')}: {record}, "
+                    f"{t.get('points_for', 0):.1f} PF · {t.get('status','alive')}{marker}"
+                )
+
+    parts.append("")
+    parts.append(f"Open Xomper: {XOMPER_URL}")
+    return "\n".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Section renderers — HTML helpers kept private to this module
+# ---------------------------------------------------------------------------
+
+
+def _section_header(label: str) -> str:
+    """Inline section divider with uppercase label. Matches the
+    `generate_section_title` look-and-feel but smaller (sub-sections)."""
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 0 24px 8px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">
+                {_escape(label)}
+            </td>
+        </tr>
+    </table>
+    """
+
+
+def _standings_section(
+    standings: list[tuple[str, int, int, int, float]],
+    user_team_name: str,
+) -> str:
+    rows = ""
+    for idx, (team, w, l, t, pf) in enumerate(standings):
+        is_mine = team == user_team_name
+        bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
+        weight = "700" if is_mine else "400"
+        team_color = TEXT_PRIMARY if is_mine else TEXT_SECONDARY
+        record = f"{w}-{l}-{t}" if t else f"{w}-{l}"
+        rows += f"""
+        <tr>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_MUTED}; width: 28px;">{idx + 1}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 14px; color: {team_color}; font-weight: {weight};">{_escape(team)}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{record}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{pf:.1f}</td>
+        </tr>
+        """
+    return f"""
+    {_section_header("Standings")}
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 0 24px 16px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                       style="border: 1px solid {SURFACE_LIGHT}; border-radius: 8px; overflow: hidden;">
+                    <tr style="background-color: {DARK_NAVY};">
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">#</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">Team</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase; text-align: right;" align="right">Record</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase; text-align: right;" align="right">PF</td>
+                    </tr>
+                    {rows}
+                </table>
+            </td>
+        </tr>
+    </table>
+    """
+
+
+def _bracket_section(
+    bracket_rounds: list[tuple[str, list[tuple[str, float, str, float]]]],
+) -> str:
+    blocks = ""
+    for round_label, pairs in bracket_rounds:
+        row_html = ""
+        for a, sa, b, sb in pairs:
+            if sa is not None and sb is not None:
+                a_winner = sa > sb
+                b_winner = sb > sa
+                a_color = SUCCESS_GREEN if a_winner else (ACCENT_RED if b_winner else TEXT_SECONDARY)
+                b_color = SUCCESS_GREEN if b_winner else (ACCENT_RED if a_winner else TEXT_SECONDARY)
+                row_html += f"""
+                <tr>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {a_color}; font-weight: 700;">{_escape(a)}</td>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {a_color}; text-align: right;" align="right">{sa:.1f}</td>
+                    <td style="padding: 6px 6px; font-family: {FONT_BODY}; font-size: 11px; color: {TEXT_MUTED}; text-align: center;" align="center">vs</td>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {b_color}; text-align: right;" align="right">{sb:.1f}</td>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {b_color}; font-weight: 700;">{_escape(b)}</td>
+                </tr>
+                """
+            else:
+                row_html += f"""
+                <tr>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY};">{_escape(a)}</td>
+                    <td colspan="3" style="padding: 6px 6px; font-family: {FONT_BODY}; font-size: 11px; color: {TEXT_MUTED}; text-align: center;" align="center">vs</td>
+                    <td style="padding: 6px 12px; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY};">{_escape(b)}</td>
+                </tr>
+                """
+        blocks += f"""
+        <tr>
+            <td style="padding: 6px 24px 4px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {CHAMPION_GOLD}; letter-spacing: 1px; text-transform: uppercase;">{_escape(round_label)}</td>
+        </tr>
+        <tr>
+            <td style="padding: 0 24px 12px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                       style="border: 1px solid {SURFACE_LIGHT}; border-radius: 8px;">
+                    {row_html}
+                </table>
+            </td>
+        </tr>
+        """
+    return f"""
+    {_section_header("Playoff Bracket")}
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        {blocks}
+    </table>
+    """
+
+
+def _worldcup_section(
+    wc_personal: dict | None,
+    wc_divisions: list[tuple[str, list[dict]]] | None,
+) -> str:
+    personal_block = ""
+    if wc_personal:
+        div = _escape(wc_personal.get("division") or "")
+        pos = wc_personal.get("position") or "?"
+        status = (wc_personal.get("status") or "alive").lower()
+        status_color = {
+            "clinched": SUCCESS_GREEN,
+            "eliminated": ACCENT_RED,
+            "alive": CHAMPION_GOLD,
+        }.get(status, TEXT_SECONDARY)
+        record_bits: list[str] = []
+        if wc_personal.get("wins") is not None:
+            w = wc_personal.get("wins", 0)
+            l = wc_personal.get("losses", 0)
+            t = wc_personal.get("ties", 0)
+            record_bits.append(f"{w}-{l}-{t}" if t else f"{w}-{l}")
+        if wc_personal.get("points_for") is not None:
+            record_bits.append(f"{wc_personal['points_for']:.1f} PF")
+        pb = wc_personal.get("points_back")
+        pb_line = (
+            f"<p style='margin: 4px 0 0; color: {TEXT_SECONDARY}; font-size: 13px;'>"
+            f"{pb:.1f} pts back from a qualifying spot</p>"
+            if pb is not None else ""
+        )
+        personal_block = f"""
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            <tr>
+                <td style="padding: 0 24px 12px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                           style="border: 1px solid {status_color}; border-radius: 8px;">
+                        <tr>
+                            <td style="padding: 12px 14px; font-family: {FONT_BODY}; color: {TEXT_PRIMARY};">
+                                <p style="margin: 0; font-size: 15px;">
+                                    You are <strong style="color: {status_color};">#{pos} in {div}</strong>
+                                    — <span style="color: {status_color}; text-transform: uppercase; font-size: 12px; letter-spacing: 1px;">{_escape(status)}</span>
+                                </p>
+                                {('<p style="margin: 4px 0 0; color: ' + TEXT_SECONDARY + '; font-size: 13px;">' + ' · '.join(record_bits) + '</p>') if record_bits else ''}
+                                {pb_line}
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+        """
+
+    full_block = ""
+    if wc_divisions:
+        div_blocks = ""
+        for div_name, teams in wc_divisions:
+            rows = ""
+            for idx, t in enumerate(teams):
+                is_user = bool(t.get("is_user"))
+                status = (t.get("status") or "alive").lower()
+                marker = " ⭐" if status == "clinched" else (" ✕" if status == "eliminated" else "")
+                bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
+                name_color = CHAMPION_GOLD if is_user else (TEXT_PRIMARY if status == "clinched" else TEXT_SECONDARY)
+                weight = "700" if is_user else "400"
+                w = t.get("wins", 0)
+                l = t.get("losses", 0)
+                tie = t.get("ties", 0)
+                record = f"{w}-{l}-{tie}" if tie else f"{w}-{l}"
+                rows += f"""
+                <tr>
+                    <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {name_color}; font-weight: {weight};">{_escape(t.get('team_name', ''))}{marker}</td>
+                    <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{record}</td>
+                    <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{t.get('points_for', 0):.1f}</td>
+                </tr>
+                """
+            div_blocks += f"""
+            <tr>
+                <td style="padding: 6px 24px 4px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {CHAMPION_GOLD}; letter-spacing: 1px; text-transform: uppercase;">{_escape(div_name)}</td>
+            </tr>
+            <tr>
+                <td style="padding: 0 24px 12px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                           style="border: 1px solid {SURFACE_LIGHT}; border-radius: 8px; overflow: hidden;">
+                        {rows}
+                    </table>
+                </td>
+            </tr>
+            """
+        full_block = f"""
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+            {div_blocks}
+        </table>
+        """
+
+    if not personal_block and not full_block:
+        return ""
+
+    return f"""
+    {_section_header("World Cup")}
+    {personal_block}
+    {full_block}
+    """

--- a/lambdas/common/worldcup_helper.py
+++ b/lambdas/common/worldcup_helper.py
@@ -261,6 +261,89 @@ def get_league_chain(
     return chain
 
 
+def gather_chain_matchups(
+    chain: list[dict[str, Any]],
+    total_regular_weeks: int,
+    fetch_rosters_fn,
+    fetch_users_fn,
+    fetch_matchups_fn,
+    log_fn=None,
+) -> list[dict[str, Any]]:
+    """Walk every league in `chain`, pull users + rosters + every
+    regular-season week, pair matchups by `matchup_id`, and emit
+    MatchupHistoryRecord-shaped dicts. Used as input to
+    `compute_division_standings`.
+
+    Dependencies are passed in (rather than imported here) so this
+    stays free of Sleeper / boto3 coupling — the live callers wire
+    in `get_sleeper_league_rosters` / `_users` / `_matchups` from
+    `sleeper_helper`. Tests can pass fakes.
+
+    Skips leagues with `status == "pre_draft"` (no games yet).
+    """
+    records: list[dict[str, Any]] = []
+    for league in chain:
+        if league.get("status") == "pre_draft":
+            continue
+        league_id = league["league_id"]
+        season = league.get("season", "")
+        rosters = fetch_rosters_fn(league_id) or []
+        users = fetch_users_fn(league_id) or []
+        roster_by_id = {r["roster_id"]: r for r in rosters}
+        user_by_id = {u["user_id"]: u for u in users}
+
+        for week in range(1, total_regular_weeks + 1):
+            try:
+                week_matchups = fetch_matchups_fn(league_id, week)
+            except Exception as e:
+                if log_fn:
+                    log_fn(f"Week {week} matchup fetch failed for {league_id}: {e}")
+                continue
+
+            grouped: dict[int, list[dict[str, Any]]] = {}
+            for m in week_matchups or []:
+                mid = m.get("matchup_id")
+                if mid is None:
+                    continue
+                grouped.setdefault(mid, []).append(m)
+
+            for pair in grouped.values():
+                if len(pair) != 2:
+                    continue
+                a, b = pair
+                roster_a = roster_by_id.get(a["roster_id"]) or {}
+                roster_b = roster_by_id.get(b["roster_id"]) or {}
+                user_a = user_by_id.get(roster_a.get("owner_id") or "") or {}
+                user_b = user_by_id.get(roster_b.get("owner_id") or "") or {}
+                a_pts = float(a.get("points") or 0)
+                b_pts = float(b.get("points") or 0)
+                if a_pts > b_pts:
+                    winner = a["roster_id"]
+                elif b_pts > a_pts:
+                    winner = b["roster_id"]
+                else:
+                    winner = None
+
+                records.append({
+                    "league_id": league_id,
+                    "season": season,
+                    "week": week,
+                    "team_a_user_id": roster_a.get("owner_id") or "",
+                    "team_a_username": user_a.get("username") or "",
+                    "team_a_team_name": (user_a.get("metadata") or {}).get("team_name") or user_a.get("display_name") or "",
+                    "team_a_division": roster_a.get("settings", {}).get("division") or 0,
+                    "team_a_points": a_pts,
+                    "team_b_user_id": roster_b.get("owner_id") or "",
+                    "team_b_username": user_b.get("username") or "",
+                    "team_b_team_name": (user_b.get("metadata") or {}).get("team_name") or user_b.get("display_name") or "",
+                    "team_b_division": roster_b.get("settings", {}).get("division") or 0,
+                    "team_b_points": b_pts,
+                    "winner_roster_id": winner,
+                    "is_playoff": week > 14,
+                })
+    return records
+
+
 def division_name_map_from_league(league: dict[str, Any]) -> dict[int, str]:
     """Sleeper stores division names in `league.metadata.division_1`,
     `division_2`, ... Build a {1: "AFC East", 2: "NFC West", ...} dict.

--- a/lambdas/notif_weekly_recap/handler.py
+++ b/lambdas/notif_weekly_recap/handler.py
@@ -17,7 +17,9 @@ content and sends again. Acceptable for a recap (low blast radius);
 if needed, gate behind a DynamoDB "last sent week" record.
 """
 from typing import Any
+import requests
 from lambdas.common.admin_only_filter import filter_to_admin_only
+from lambdas.common.constants import TOTAL_REGULAR_WEEKS
 from lambdas.common.cron_settings import get_cron_setting
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
@@ -39,6 +41,12 @@ from lambdas.common.ses_helper import send_emails_concurrently
 from lambdas.common.email_templates import (
     generate_weekly_recap_email,
     generate_weekly_recap_email_plain_text,
+)
+from lambdas.common.worldcup_helper import (
+    compute_division_standings,
+    division_name_map_from_league,
+    gather_chain_matchups,
+    get_league_chain,
 )
 
 log = get_logger(__file__)
@@ -140,6 +148,71 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         reverse=True,
     )
 
+    # Cumulative season standings — read directly from each roster's
+    # settings block (Sleeper's source of truth for W-L + PF). Sorted
+    # wins-DESC, then PF-DESC for the email's standings table.
+    def _roster_pf(r: dict[str, Any]) -> float:
+        s = r.get("settings") or {}
+        return float(s.get("fpts", 0)) + float(s.get("fpts_decimal", 0)) / 100.0
+
+    standings_rows: list[tuple[str, int, int, int, float]] = sorted(
+        [
+            (
+                team_name_for_roster(r["roster_id"]),
+                int((r.get("settings") or {}).get("wins", 0)),
+                int((r.get("settings") or {}).get("losses", 0)),
+                int((r.get("settings") or {}).get("ties", 0)),
+                _roster_pf(r),
+            )
+            for r in rosters
+        ],
+        key=lambda t: (t[1], t[4]),
+        reverse=True,
+    )
+
+    # Playoff bracket — only fetch from Sleeper once the playoffs are
+    # near (week >= 12) so we don't burn a network call every Tuesday
+    # in September. Sleeper materializes the bracket once the
+    # commissioner sets playoff_week_start in league settings.
+    bracket_rounds_payload: list[tuple[str, list[tuple[str, float, str, float]]]] | None = None
+    if target_week >= 12:
+        try:
+            br_resp = requests.get(
+                f"https://api.sleeper.app/v1/league/{league_id}/winners_bracket",
+                timeout=10,
+            )
+            bracket_raw = br_resp.json() if br_resp.status_code == 200 else []
+        except Exception as e:
+            log.warning(f"winners_bracket fetch failed: {e}")
+            bracket_raw = []
+        if bracket_raw:
+            bracket_rounds_payload = _bracket_to_rounds(
+                bracket_raw,
+                team_name_for_roster,
+            )
+
+    # World Cup standings — walk the league chain and aggregate
+    # divisional matchups across all seasons. Heavyweight (many
+    # Sleeper calls) so we compute once before the per-manager loop.
+    wc_full_payload: list[tuple[str, list[dict[str, Any]]]] | None = None
+    wc_by_user: dict[str, dict[str, Any]] = {}
+    try:
+        chain = get_league_chain(league_id, fetch_league_fn=get_sleeper_league)
+        head_league = chain[0] if chain else {}
+        div_names = division_name_map_from_league(head_league)
+        chain_matchups = gather_chain_matchups(
+            chain,
+            total_regular_weeks=TOTAL_REGULAR_WEEKS,
+            fetch_rosters_fn=get_sleeper_league_rosters,
+            fetch_users_fn=get_sleeper_league_users,
+            fetch_matchups_fn=get_sleeper_league_matchups,
+            log_fn=log.warning,
+        )
+        wc_standings = compute_division_standings(chain_matchups, div_names)
+        wc_full_payload, wc_by_user = _wc_to_template_payload(wc_standings)
+    except Exception as e:
+        log.warning(f"World Cup computation failed; skipping WC sections: {e}")
+
     push_sent = 0
     email_tasks: list[tuple[str, str, str, str]] = []
 
@@ -192,34 +265,29 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                 or "Manager"
             )
             subject = f"Week {target_week} {league_name} recap"
-            html = generate_weekly_recap_email(
-                manager_name=manager_name,
-                league_name=league_name,
-                week=target_week,
-                user_team_name=user_team_name,
-                user_points=me_pts,
-                opponent_team_name=opp_team_name,
-                opponent_points=opp_pts,
-                user_won=user_won,
-                is_tie=is_tie,
-                league_high_team=top_team_name,
-                league_high_points=top_pts,
-                all_scores=all_scores,
-            )
-            text = generate_weekly_recap_email_plain_text(
-                manager_name=manager_name,
-                league_name=league_name,
-                week=target_week,
-                user_team_name=user_team_name,
-                user_points=me_pts,
-                opponent_team_name=opp_team_name,
-                opponent_points=opp_pts,
-                user_won=user_won,
-                is_tie=is_tie,
-                league_high_team=top_team_name,
-                league_high_points=top_pts,
-                all_scores=all_scores,
-            )
+            wc_personal = wc_by_user.get(owner_id)
+            template_kwargs: dict[str, Any] = {
+                "manager_name": manager_name,
+                "league_name": league_name,
+                "week": target_week,
+                "user_team_name": user_team_name,
+                "user_points": me_pts,
+                "opponent_team_name": opp_team_name,
+                "opponent_points": opp_pts,
+                "user_won": user_won,
+                "is_tie": is_tie,
+                "league_high_team": top_team_name,
+                "league_high_points": top_pts,
+                "all_scores": all_scores,
+                "standings": standings_rows,
+                "bracket_rounds": bracket_rounds_payload,
+                "wc_personal": wc_personal,
+                # Mark only the current recipient as `is_user` so the
+                # full-WC table highlights their row, not every row.
+                "wc_divisions": _mark_user_in_wc(wc_full_payload, owner_id) if wc_full_payload else None,
+            }
+            html = generate_weekly_recap_email(**template_kwargs)
+            text = generate_weekly_recap_email_plain_text(**template_kwargs)
             email_tasks.append((email, subject, html, text))
 
     email_sent, email_failed = (0, 0)
@@ -240,3 +308,133 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         },
         is_api=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# Section payload builders
+# ---------------------------------------------------------------------------
+
+
+def _bracket_to_rounds(
+    bracket_raw: list[dict[str, Any]],
+    team_name_for_roster,
+) -> list[tuple[str, list[tuple[str, float, str, float]]]]:
+    """Convert Sleeper's winners_bracket array into the template's
+    (round_label, [(team_a, score_a, team_b, score_b)]) shape.
+
+    Sleeper item shape: {r: round, m: matchup_id, t1, t2 (roster ids
+    or {w: prev_m} placeholders), w, l (resolved winner/loser),
+    t1_from, t2_from}. Scores aren't in the bracket payload — we use
+    `None` for unplayed matchups so the template renders an "X vs Y"
+    line without scores.
+    """
+    rounds: dict[int, list[tuple[str, float | None, str, float | None]]] = {}
+    for item in bracket_raw:
+        rd = int(item.get("r") or 0)
+        if rd <= 0:
+            continue
+        t1 = item.get("t1")
+        t2 = item.get("t2")
+        a_name = team_name_for_roster(t1) if isinstance(t1, int) else "TBD"
+        b_name = team_name_for_roster(t2) if isinstance(t2, int) else "TBD"
+        # Scores not on the bracket payload; leave None.
+        rounds.setdefault(rd, []).append((a_name, None, b_name, None))
+
+    # Generic per-round labels — Sleeper bracket payloads don't carry
+    # explicit "Quarterfinal" / "Semifinal" tags, so derive from
+    # round count: last round is "Championship", second-to-last is
+    # "Semifinals", etc.
+    sorted_rounds = sorted(rounds.keys())
+    label_for: dict[int, str] = {}
+    total = len(sorted_rounds)
+    for idx, rd in enumerate(sorted_rounds):
+        depth_from_end = total - idx
+        if depth_from_end == 1:
+            label_for[rd] = "Championship"
+        elif depth_from_end == 2:
+            label_for[rd] = "Semifinals"
+        elif depth_from_end == 3:
+            label_for[rd] = "Quarterfinals"
+        else:
+            label_for[rd] = f"Round {rd}"
+
+    return [(label_for[rd], rounds[rd]) for rd in sorted_rounds]
+
+
+def _wc_to_template_payload(
+    wc_standings: list[tuple[int, str, list[Any]]],
+) -> tuple[list[tuple[str, list[dict[str, Any]]]], dict[str, dict[str, Any]]]:
+    """Convert `compute_division_standings` output into the template's
+    full-table shape AND a per-user lookup so the per-recipient
+    personal panel can be built without re-running the aggregation.
+
+    Returns:
+        (wc_divisions, by_user) where
+        wc_divisions = [(division_name, [{team_name, wins, losses,
+                       ties, points_for, status, is_user}])]
+        by_user      = {user_id: {division, position, status, wins,
+                       losses, ties, points_for, points_back}}
+    """
+    wc_divisions: list[tuple[str, list[dict[str, Any]]]] = []
+    by_user: dict[str, dict[str, Any]] = {}
+
+    for _div_id, div_name, teams in wc_standings:
+        # `teams` is sorted wins-DESC then PF-DESC. The conservative
+        # cutoff for top-2 is element index 1's wins (worst clinched
+        # wins) — anyone below that AND below by enough wins is
+        # eliminated; otherwise alive. The clinch_status field is set
+        # by clinch_for_division upstream.
+        cutoff_wins = teams[1].wins if len(teams) >= 2 else 0
+        team_dicts: list[dict[str, Any]] = []
+        for position, t in enumerate(teams, start=1):
+            team_dicts.append({
+                "team_name": t.team_name,
+                "user_id": t.user_id,
+                "wins": t.wins,
+                "losses": t.losses,
+                "ties": t.ties,
+                "points_for": t.points_for,
+                "status": t.clinch_status,
+                # `is_user` is filled in per-recipient via
+                # `_mark_user_in_wc`.
+                "is_user": False,
+            })
+            points_back = None
+            if position > 2 and t.clinch_status != "eliminated":
+                # Rough proxy — how many wins back from the 2-seed.
+                wins_back = max(cutoff_wins - t.wins, 0)
+                if wins_back > 0:
+                    points_back = float(wins_back) * 100.0  # placeholder magnitude
+            by_user[t.user_id] = {
+                "division": div_name,
+                "position": position,
+                "status": t.clinch_status,
+                "wins": t.wins,
+                "losses": t.losses,
+                "ties": t.ties,
+                "points_for": t.points_for,
+                "points_back": points_back,
+            }
+        wc_divisions.append((div_name, team_dicts))
+
+    return wc_divisions, by_user
+
+
+def _mark_user_in_wc(
+    wc_divisions: list[tuple[str, list[dict[str, Any]]]],
+    user_id: str,
+) -> list[tuple[str, list[dict[str, Any]]]]:
+    """Return a copy of `wc_divisions` with `is_user=True` on the one
+    row whose `user_id` matches `user_id` (anywhere across divisions).
+    Lets each manager's email highlight only their own row without
+    re-aggregating everything per recipient."""
+    if not user_id:
+        return wc_divisions
+    out: list[tuple[str, list[dict[str, Any]]]] = []
+    for div_name, rows in wc_divisions:
+        out_rows = [
+            {**row, "is_user": row.get("user_id") == user_id}
+            for row in rows
+        ]
+        out.append((div_name, out_rows))
+    return out


### PR DESCRIPTION
Three new sections on the weekly_recap email:

1. **Cumulative standings** (always) — W-L-T + PF per team
2. **Playoff bracket** (week >= 12) — from Sleeper's winners_bracket endpoint
3. **World Cup** (always when computable) — personal panel on top, full 4-division table below

Promotes `gather_chain_matchups` to `worldcup_helper.py` so both notif_weekly_recap and notif_worldcup_movement can compute WC standings without depending on each other.

Failure-tolerant — bracket + WC each wrapped in try/except; email still ships if either fetch fails.

## Preview now
Test Email screen, kind = Weekly Recap (non-AI) → fires the updated fixture (Week 14 + sample bracket + sample WC). The next render shows all three new sections.