### PR TITLE
feat(week-preview): AI prompt + email template + test fixture (PR 1 of 4)

### DIFF
--- a/lambdas/api_admin_email_test_template/handler.py
+++ b/lambdas/api_admin_email_test_template/handler.py
@@ -54,6 +54,8 @@ from lambdas.common.email_templates import (
     generate_taxi_steal_league_email_plain_text,
     generate_taxi_steal_owner_email,
     generate_taxi_steal_owner_email_plain_text,
+    generate_week_preview_email,
+    generate_week_preview_email_plain_text,
 )
 from lambdas.common.errors import handle_errors
 from lambdas.common.logger import get_logger
@@ -244,7 +246,149 @@ _FIXTURES: dict[str, dict[str, Any]] = {
             "pick_cost": "2027 3rd-round pick",
         },
     },
+    "week_preview": {
+        "subject": f"[TEST] Week 12 {_LEAGUE_NAME} preview",
+        "params": {
+            "manager_name": "Dom",
+            "league_name": _LEAGUE_NAME,
+            "week": 12,
+            # Pre-rendered markdown body — mirrors what Claude will
+            # produce against the week_preview_prompts.py system blocks
+            # so the visual layout is testable before the cron lambda
+            # is wired.
+            "body_markdown": _WEEK_PREVIEW_SAMPLE_BODY,
+            "standings": [
+                ("Gangsters of Love",      9, 2, 0, 1422.0),
+                ("Nvr 4get Da CLT",        7, 4, 0, 1284.3),
+                ("ktatich",                8, 3, 0, 1351.2),
+                ("The Goffather",          7, 4, 0, 1297.8),
+                ("Wake Forest Factory",    7, 4, 0, 1306.4),
+                ("Brock Party",            6, 5, 0, 1241.9),
+                ("Sinnott Committee",      6, 5, 0, 1230.5),
+                ("Shits and Gibbles",      4, 7, 0, 1188.5),
+                ("Shane Beamer's Burner",  5, 6, 0, 1198.0),
+                ("gniadek",                3, 8, 0, 1142.7),
+                ("reesegriffin",           2, 9, 0, 1098.6),
+                ("Nico Suave",             1, 10, 0, 1054.1),
+            ],
+            "wc_divisions": [
+                ("East Division", [
+                    {"team_name": "Gangsters of Love",   "wins": 9, "losses": 2, "ties": 0, "points_for": 1422.0, "status": "clinched"},
+                    {"team_name": "Nvr 4get Da CLT",     "wins": 7, "losses": 4, "ties": 0, "points_for": 1284.3, "status": "clinched"},
+                    {"team_name": "Shits and Gibbles",   "wins": 4, "losses": 7, "ties": 0, "points_for": 1188.5, "status": "eliminated"},
+                ]),
+                ("West Division", [
+                    {"team_name": "ktatich",             "wins": 8, "losses": 3, "ties": 0, "points_for": 1351.2, "status": "clinched"},
+                    {"team_name": "The Goffather",       "wins": 7, "losses": 4, "ties": 0, "points_for": 1297.8, "status": "alive"},
+                    {"team_name": "reesegriffin",        "wins": 2, "losses": 9, "ties": 0, "points_for": 1098.6, "status": "eliminated"},
+                ]),
+                ("North Division", [
+                    {"team_name": "Wake Forest Factory", "wins": 7, "losses": 4, "ties": 0, "points_for": 1306.4, "status": "clinched"},
+                    {"team_name": "Brock Party",         "wins": 6, "losses": 5, "ties": 0, "points_for": 1241.9, "status": "alive"},
+                    {"team_name": "gniadek",             "wins": 3, "losses": 8, "ties": 0, "points_for": 1142.7, "status": "alive"},
+                ]),
+                ("South Division", [
+                    {"team_name": "Sinnott Committee",   "wins": 6, "losses": 5, "ties": 0, "points_for": 1230.5, "status": "alive"},
+                    {"team_name": "Shane Beamer's Burner","wins": 5, "losses": 6, "ties": 0, "points_for": 1198.0, "status": "alive"},
+                    {"team_name": "Nico Suave",          "wins": 1, "losses": 10, "ties": 0, "points_for": 1054.1, "status": "eliminated"},
+                ]),
+            ],
+        },
+    },
 }
+
+
+# Sample markdown body for the week_preview test fixture. Hand-tuned
+# to mirror what week_preview_prompts.py asks Claude to produce so the
+# preview render exercises every section.
+_WEEK_PREVIEW_SAMPLE_BODY = """# Week 12 Preview
+
+Three teams sit at 7-4 with the playoff cutoff drawing daylight. This is the week the standings start mattering — every game pushes someone toward a bye and someone else toward the bubble.
+
+## World Cup Watch
+
+East already locked. **Nvr 4get Da CLT** and **Gangsters of Love** have both clinched their two seeds. West is the live one — **The Goffather** sitting 7-4 needs the **ktatich** loss + a Tibor win to flip the order. North is settled (Wake clinched), but **gniadek** at 3-8 isn't mathematically eliminated yet and that's almost more embarrassing than getting eliminated cleanly.
+
+## Team-by-Team
+
+### Gangsters of Love (9-2)
+
+Luke can stop trying. Top seed is one win away, the dynasty is rolling, the wallpaper is laminated. This week he could trot out his JV squad and probably still drop 140.
+
+### ktatich (8-3)
+
+Kyle's PF says he's the most talented team in the league and his record says he's a top-3 seed. Both are true. This week's game is the kind he wins comfortably or drops by 4 — there is no middle for him.
+
+### Nvr 4get Da CLT (7-4)
+
+Dom needs to stack a win on top of clinch glow. The 7-4 record paints a tighter race than the PF agrees with — playoff math says #2 seed is genuinely in play if Gangsters slip even once.
+
+### The Goffather (7-4)
+
+Tibor is one of three teams within points-back range of a bye. The schedule does him no favors this week, but the WC math is the only one that matters and he's already alive there.
+
+### Wake Forest Factory (7-4)
+
+Grant's record looks like it should be 8-3 and the PF agrees. He's the one team in this tier that's been consistently unlucky, which means this is the week where karma either pays out or he loses by 2 again.
+
+### Brock Party (6-5)
+
+Michael has won three in a row and is suddenly back in the playoff conversation. The 6-5 is fragile — drop one this week and the math gets very ugly very fast.
+
+### Sinnott Committee (6-5)
+
+Duncan's bench-points number is the worst in the league which is a real choice. If he sets his starters straight one time the 6-5 starts looking a lot more like a 7-4.
+
+### Shits and Gibbles (4-7)
+
+Tony needs to win out + get help. He won't. But he might cause damage on the way down and that's worth tuning in for.
+
+### Shane Beamer's Burner (5-6)
+
+Alex's name remains undefeated. The roster — less so. This week is for spoiler points.
+
+### gniadek (3-8)
+
+Jim. Mathematically alive. Statistically not. Spiritually somewhere in between.
+
+### reesegriffin (2-9)
+
+Reese has the lowest PF in the league and the lore says we don't ask why. This week he plays The Goffather and that should not be close.
+
+### Nico Suave (1-10)
+
+The Suave 12 seed is locked. He drafts at 1.01 next year. We are watching a man choose violence on next year's rookie pool.
+
+## Game by Game
+
+### Gangsters of Love (9-2) vs Sinnott Committee (6-5)
+
+Luke is on cruise control; Duncan is one bench-points-correction away from being 7-4. Stake: Luke's #1 seed solidifies, Duncan keeps WC alive in South.
+
+### ktatich (8-3) vs Wake Forest Factory (7-4)
+
+Game of the week. Two teams with top-3 PF and identical vibes (talented, slightly under-recorded). Loser is suddenly in trouble for the bye.
+
+### Nvr 4get Da CLT (7-4) vs Shits and Gibbles (4-7)
+
+Trap game. Dom's coming off a clinch, Tony is in spoiler mode with nothing to lose. Watch the bench.
+
+### The Goffather (7-4) vs reesegriffin (2-9)
+
+Should be the easiest path to a bye-spot push. If Tibor drops this one the playoff conversation about him stops being polite.
+
+### Brock Party (6-5) vs Shane Beamer's Burner (5-6)
+
+The "fighting for the 6 seed" matchup. Both teams own their fate this week.
+
+### gniadek (3-8) vs Nico Suave (1-10)
+
+The lottery matchup. Both managers should be tanking for picks but Jim still won't.
+
+## Bold Prediction
+
+Wake Forest Factory finally wins one of these close ones, ktatich drops the bye race, and **The Goffather** vaults to the #3 seed off the upset chaos. By Tuesday morning the top six all sit within one game of each other and the recap email gets twice as fun to write.
+"""
 
 # Wires each kind to (html builder, text builder). Listed inline so
 # the dispatch table stays in one place.
@@ -256,6 +400,7 @@ _BUILDERS = {
     "rule_denied":       (generate_rule_denied_email,       generate_rule_denied_email_plain_text),
     "taxi_steal_league": (generate_taxi_steal_league_email, generate_taxi_steal_league_email_plain_text),
     "taxi_steal_owner":  (generate_taxi_steal_owner_email,  generate_taxi_steal_owner_email_plain_text),
+    "week_preview":      (generate_week_preview_email,      generate_week_preview_email_plain_text),
 }
 
 

--- a/lambdas/common/email_templates/__init__.py
+++ b/lambdas/common/email_templates/__init__.py
@@ -33,6 +33,10 @@ from .weekly_recap import (
     generate_weekly_recap_email,
     generate_weekly_recap_email_plain_text,
 )
+from .week_preview import (
+    generate_week_preview_email,
+    generate_week_preview_email_plain_text,
+)
 
 __all__ = [
     "generate_taxi_steal_league_email",
@@ -49,4 +53,6 @@ __all__ = [
     "generate_lineup_not_set_email_plain_text",
     "generate_weekly_recap_email",
     "generate_weekly_recap_email_plain_text",
+    "generate_week_preview_email",
+    "generate_week_preview_email_plain_text",
 ]

--- a/lambdas/common/email_templates/week_preview.py
+++ b/lambdas/common/email_templates/week_preview.py
@@ -1,0 +1,273 @@
+"""
+Week Preview - Wednesday morning forward-looking newsletter
+============================================================
+Fires Wed 9am ET. Hybrid layout: AI-generated markdown body up top,
+HTML standings + World Cup standings tables below. Preview is one
+email per league (not personalized per recipient) since the content
+is forward-looking and identical for everyone.
+
+Same recipient (one-per-manager) plumbing as the weekly recap to keep
+audit + notification_log shapes consistent.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.email_templates.base import (
+    wrap_email_html,
+    generate_section_title,
+    generate_league_badge,
+    generate_button,
+    _escape,
+    CHAMPION_GOLD, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
+    DARK_NAVY, SURFACE_LIGHT, SUCCESS_GREEN, ACCENT_RED,
+    FONT_BODY, FONT_DISPLAY, XOMPER_URL,
+)
+
+
+def generate_week_preview_email(
+    *,
+    manager_name: str,
+    league_name: str,
+    week: int,
+    body_markdown: str,
+    standings: list[tuple[str, int, int, int, float]] | None = None,
+    wc_divisions: list[tuple[str, list[dict[str, Any]]]] | None = None,
+) -> str:
+    """HTML email for the Week Preview newsletter.
+
+    Args:
+        manager_name: Recipient's display name (used in the salutation).
+        league_name: Sleeper league name.
+        week: Upcoming week N.
+        body_markdown: AI-generated markdown — rendered server-side as
+            a stripped-down HTML view (we don't want to pull a full
+            markdown parser into the lambda layer, so we treat the body
+            as already-formatted text with `\\n\\n` paragraph breaks +
+            `#`/`##`/`###` headings).
+        standings: cumulative standings — (team, wins, losses, ties, pf).
+        wc_divisions: World Cup standings by division.
+    """
+    safe_manager = _escape(manager_name)
+    safe_league = _escape(league_name)
+    body_html = _markdown_to_email_html(body_markdown or "")
+    standings_html = _standings_section(standings) if standings else ""
+    wc_html = _wc_section(wc_divisions) if wc_divisions else ""
+
+    content = f"""
+    {generate_section_title(f"Week {week} Preview")}
+    {generate_league_badge(safe_league) if safe_league else ""}
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 0 24px 16px; font-family: {FONT_BODY}; font-size: 16px; color: {TEXT_PRIMARY}; line-height: 1.6;">
+                <p style="margin: 0 0 12px;">Hey {safe_manager},</p>
+                <p style="margin: 0; color: {TEXT_SECONDARY}; font-size: 14px;">
+                    Sunday's slate is locked. Here's what's at stake this week.
+                </p>
+            </td>
+        </tr>
+    </table>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 0 24px 16px; font-family: {FONT_BODY}; font-size: 15px; color: {TEXT_PRIMARY}; line-height: 1.55;">
+                {body_html}
+            </td>
+        </tr>
+    </table>
+
+    {standings_html}
+    {wc_html}
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td align="center" style="padding: 0 24px 24px;">
+                {generate_button("Open Xomper", XOMPER_URL)}
+            </td>
+        </tr>
+    </table>
+    """
+
+    preheader = f"Week {week} preview — bracket, World Cup, game by game."
+    return wrap_email_html(content, preheader_text=preheader)
+
+
+def generate_week_preview_email_plain_text(
+    *,
+    manager_name: str,
+    league_name: str,
+    week: int,
+    body_markdown: str,
+    standings: list[tuple[str, int, int, int, float]] | None = None,
+    wc_divisions: list[tuple[str, list[dict[str, Any]]]] | None = None,
+) -> str:
+    parts: list[str] = [
+        f"Hey {manager_name},",
+        "",
+        f"Week {week} {league_name} preview.",
+        "",
+        body_markdown.strip(),
+    ]
+    if standings:
+        parts.append("")
+        parts.append("Standings:")
+        for i, (team, w, l, t, pf) in enumerate(standings):
+            record = f"{w}-{l}-{t}" if t else f"{w}-{l}"
+            parts.append(f"{i + 1}. {team}: {record}, {pf:.1f} PF")
+    if wc_divisions:
+        parts.append("")
+        parts.append("World Cup:")
+        for div_name, rows in wc_divisions:
+            parts.append(f"  {div_name}")
+            for r in rows:
+                w = r.get("wins", 0); l = r.get("losses", 0); t = r.get("ties", 0)
+                record = f"{w}-{l}-{t}" if t else f"{w}-{l}"
+                parts.append(
+                    f"    {r.get('team_name', '')}: {record}, "
+                    f"{r.get('points_for', 0):.1f} PF · {r.get('status', 'alive')}"
+                )
+    parts.append("")
+    parts.append(f"Open Xomper: {XOMPER_URL}")
+    return "\n".join(parts) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Lightweight markdown → HTML pass tailored to the AI body's shape.
+#
+# We DON'T pull a real markdown parser into the lambda layer (extra
+# weight, more deps to keep on cp313). The AI's output is constrained
+# to a small subset by the prompt — `#`/`##`/`###` headings, blank-line
+# paragraphs, `**bold**`, list dashes — so a 20-line stub covers it.
+# ---------------------------------------------------------------------------
+
+
+def _markdown_to_email_html(md: str) -> str:
+    if not md.strip():
+        return ""
+    blocks = [b.strip() for b in md.split("\n\n") if b.strip()]
+    out_parts: list[str] = []
+    for block in blocks:
+        out_parts.append(_render_block(block))
+    return "\n".join(out_parts)
+
+
+def _render_block(block: str) -> str:
+    # Headings
+    if block.startswith("### "):
+        text = _inline(block[4:].strip())
+        return f'<h3 style="margin: 16px 0 6px; font-family: {FONT_DISPLAY}; font-size: 15px; color: {CHAMPION_GOLD}; font-weight: 700;">{text}</h3>'
+    if block.startswith("## "):
+        text = _inline(block[3:].strip())
+        return f'<h2 style="margin: 24px 0 8px; font-family: {FONT_DISPLAY}; font-size: 18px; color: {CHAMPION_GOLD}; font-weight: 700; text-transform: uppercase; letter-spacing: 1px;">{text}</h2>'
+    if block.startswith("# "):
+        text = _inline(block[2:].strip())
+        return f'<h1 style="margin: 8px 0 12px; font-family: {FONT_DISPLAY}; font-size: 22px; color: {TEXT_PRIMARY}; font-weight: 700;">{text}</h1>'
+    # Quote
+    if block.startswith("> "):
+        text = _inline(block[2:].strip())
+        return f'<blockquote style="margin: 8px 0; padding: 8px 14px; border-left: 3px solid {CHAMPION_GOLD}; color: {TEXT_SECONDARY}; font-style: italic;">{text}</blockquote>'
+    # Plain paragraph — inline bold + bare line
+    text = _inline(block.replace("\n", "<br/>"))
+    return f'<p style="margin: 0 0 10px; line-height: 1.55;">{text}</p>'
+
+
+def _inline(text: str) -> str:
+    # Escape first, then re-introduce bold spans.
+    escaped = _escape(text)
+    # Naive **bold** pass — handles the AI's standard `**X**` usage.
+    out = ""
+    i = 0
+    while i < len(escaped):
+        if escaped[i:i + 2] == "**":
+            end = escaped.find("**", i + 2)
+            if end == -1:
+                out += escaped[i:]
+                break
+            out += f'<strong style="color: {TEXT_PRIMARY};">{escaped[i + 2:end]}</strong>'
+            i = end + 2
+        else:
+            out += escaped[i]
+            i += 1
+    return out
+
+
+def _standings_section(
+    standings: list[tuple[str, int, int, int, float]],
+) -> str:
+    rows = ""
+    for idx, (team, w, l, t, pf) in enumerate(standings):
+        bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
+        record = f"{w}-{l}-{t}" if t else f"{w}-{l}"
+        rows += f"""
+        <tr>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_MUTED}; width: 28px;">{idx + 1}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 14px; color: {TEXT_PRIMARY};">{_escape(team)}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{record}</td>
+            <td style="padding: 8px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{pf:.1f}</td>
+        </tr>
+        """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 6px 24px 4px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">League Pulse</td>
+        </tr>
+        <tr>
+            <td style="padding: 0 24px 16px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                       style="border: 1px solid {SURFACE_LIGHT}; border-radius: 8px; overflow: hidden;">
+                    <tr style="background-color: {DARK_NAVY};">
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">#</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">Team</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase; text-align: right;" align="right">Record</td>
+                        <td style="padding: 10px 12px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase; text-align: right;" align="right">PF</td>
+                    </tr>
+                    {rows}
+                </table>
+            </td>
+        </tr>
+    </table>
+    """
+
+
+def _wc_section(
+    wc_divisions: list[tuple[str, list[dict[str, Any]]]],
+) -> str:
+    div_blocks = ""
+    for div_name, teams in wc_divisions:
+        rows = ""
+        for idx, t in enumerate(teams):
+            status = (t.get("status") or "alive").lower()
+            marker = " ⭐" if status == "clinched" else (" ✕" if status == "eliminated" else "")
+            bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
+            name_color = TEXT_PRIMARY if status == "clinched" else TEXT_SECONDARY
+            w = t.get("wins", 0); l = t.get("losses", 0); tie = t.get("ties", 0)
+            record = f"{w}-{l}-{tie}" if tie else f"{w}-{l}"
+            rows += f"""
+            <tr>
+                <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {name_color};">{_escape(t.get('team_name', ''))}{marker}</td>
+                <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{record}</td>
+                <td style="padding: 6px 12px; background-color: {bg}; font-family: {FONT_BODY}; font-size: 13px; color: {TEXT_SECONDARY}; text-align: right;" align="right">{t.get('points_for', 0):.1f}</td>
+            </tr>
+            """
+        div_blocks += f"""
+        <tr>
+            <td style="padding: 6px 24px 4px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {CHAMPION_GOLD}; letter-spacing: 1px; text-transform: uppercase;">{_escape(div_name)}</td>
+        </tr>
+        <tr>
+            <td style="padding: 0 24px 12px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                       style="border: 1px solid {SURFACE_LIGHT}; border-radius: 8px; overflow: hidden;">
+                    {rows}
+                </table>
+            </td>
+        </tr>
+        """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 6px 24px 4px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">World Cup Standings</td>
+        </tr>
+        {div_blocks}
+    </table>
+    """

--- a/lambdas/common/week_preview_prompts.py
+++ b/lambdas/common/week_preview_prompts.py
@@ -1,0 +1,219 @@
+"""
+Week Preview AI prompts
+=======================
+Builds the system + user prompts for the Wednesday-morning Week
+Preview newsletter. Mirrors `weekly_prompts.py` structure (3-block
+system, JSON-envelope output) so the orchestrator can share the
+Anthropic call shape.
+
+System blocks:
+1. Tone + safety + output structure (preview-tuned — forward-looking,
+   not a roast of last week)
+2. Lore (shared)
+3. JSON envelope contract
+
+User prompt: upcoming-week matchups, current standings, WC standings,
+prior memories, the player-id starter map for each team.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common.constants import AI_REVIEW_WEEKLY_PROMPT_VERSION
+from lambdas.common.lore_prompt import build_lore_block
+
+
+PROMPT_VERSION = AI_REVIEW_WEEKLY_PROMPT_VERSION + "-preview"
+
+
+SYSTEM_PROMPT_TONE = """You are the resident sports-talk-radio host for the Xomper fantasy football league, a 12-person dynasty league of college friends. Your job is to write the WEDNESDAY-MORNING WEEK PREVIEW NEWSLETTER — a forward-looking matchup preview for the upcoming weekend, fired before waiver claims process.
+
+Voice:
+- Same league personality as the weekly recap, but FORWARD-LOOKING. You're previewing what's about to happen, not roasting what already did.
+- Funny, unserious. Tease setups for upcoming matchups. Reference past memories from earlier in the season when relevant (continuity is funny).
+- Lean on inside jokes from the lore section. Speak to managers by name.
+- Sound like a friend at a bar handicapping the weekend — not a corporate AI assistant.
+- No corporate hedge phrases. No "however, on the other hand…". Never apologize.
+- Short punchy paragraphs.
+
+Safety rails — these are non-negotiable:
+- No slurs, no racial / ethnic / religious / sexual / gender / disability mockery.
+- No jokes about substance abuse, addiction, eating disorders, self-harm, suicide, or mental health crises.
+- No jokes about violence against people (real or implied).
+- No jokes about anyone NOT in the lore section. Do not invent league members.
+- No sexual content. Keep it PG-13 frat-house humor, not locker-room cruelty.
+- Do NOT invent NFL news, injuries, trades, arrests, or suspensions. The matchup data + player_ids in the user prompt are ground truth — if a player isn't called out as injured in the user prompt, don't claim they are.
+- Do not reference specific real-world tragedies, deaths, or news events.
+- If a roast feels like it crosses a line, soften it.
+
+Output format — CRITICAL. Respond with ONLY a single JSON object — no preamble, no code fences, no surrounding markdown. The third system block specifies the exact envelope shape.
+
+Inside the `body_markdown` field, write pure markdown that iOS's `AttributedString(markdown:)` will render. Follow this EXACT structure:
+
+1. `# Week N Preview` on its own line (N is the upcoming week from the user prompt). Blank line.
+2. One opening paragraph framing the week's biggest storyline. Blank line.
+3. `## World Cup Watch` on its own line. Blank line. One paragraph on who's on the WC bubble + clinch/elimination scenarios for this week. Blank line.
+4. `## Team-by-Team` on its own line. Blank line. For EACH of the 12 teams, in standings order (best record first):
+   - `### Team Name (W-L)` on its own line. Blank line.
+   - One 2-3 sentence paragraph: their week's stakes, key starters, momentum read. Blank line after.
+5. `## Game by Game` on its own line. Blank line. For EACH matchup pair, in any natural order:
+   - `### Team A (W-L) vs Team B (W-L)` on its own line. Blank line.
+   - One 2-3 sentence blurb: head-to-head context, key starters, playoff/WC stakes. Blank line after.
+6. `## Bold Prediction` on its own line. Blank line. One short paragraph hot take.
+
+Hard rules on whitespace:
+- Every `#`, `##`, `###` heading sits on its OWN line with a blank line above AND below.
+- No two paragraphs share a line. Always `\\n\\n` between paragraphs.
+- No HTML. No code fences. Use `**bold**` for emphasis.
+- Every paragraph references at least one concrete data point: a record, a player_id, a prior memory, a WC standing, a lore tidbit.
+
+After the markdown, return 2-4 `new_memories` summarizing THIS week's forward-looking storylines (not what already happened — what's about to). Keep each under 200 chars."""
+
+
+SYSTEM_PROMPT_OUTPUT_SPEC = """OUTPUT FORMAT — required JSON envelope
+
+You MUST respond with a single valid JSON object that matches this exact shape. No markdown code fences. No commentary outside the JSON.
+
+Schema:
+{
+  "body_markdown": "string — the full week preview as markdown",
+  "new_memories": [
+    {
+      "text": "string under 200 chars — one-line forward-looking storyline",
+      "manager_user_id": "string Sleeper user_id from the lore section, or null for league-wide memories",
+      "sentiment": "roast" | "praise" | "lore"
+    }
+  ]
+}
+
+Rules for `new_memories`:
+- 2-4 entries. Each one a specific storyline tied to a manager or matchup."""
+
+
+def build_system_blocks() -> list[dict[str, Any]]:
+    """Three-block system prompt. Tone + lore + output spec each
+    cached with `ephemeral` so cross-call cache reuse stays warm."""
+    return [
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT_TONE,
+            "cache_control": {"type": "ephemeral"},
+        },
+        build_lore_block(),
+        {
+            "type": "text",
+            "text": SYSTEM_PROMPT_OUTPUT_SPEC,
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+
+def build_user_prompt(
+    *,
+    league_name: str,
+    season: str,
+    week: int,
+    matchup_pairs: list[dict[str, Any]],
+    standings: list[dict[str, Any]],
+    wc_standings: list[dict[str, Any]],
+    recent_memories: list[dict[str, Any]],
+) -> str:
+    """Per-week preview prompt.
+
+    Args:
+        league_name: Sleeper league name.
+        season: e.g. "2026".
+        week: Upcoming week N (e.g. 12).
+        matchup_pairs: list of dicts:
+          `{matchup_id, team_a: {team_name, manager, user_id, wins,
+          losses, starters: [player_id], division}, team_b: same}`
+        standings: cumulative season standings — list of
+          `{rank, team_name, manager, user_id, wins, losses, points_for}`.
+        wc_standings: per-division WC standings — list of
+          `{division, position, team_name, user_id, wins, losses,
+          points_for, status}`.
+        recent_memories: last N items from xomper-ai-memories — list
+          of `{text, manager_user_id, sentiment, week, season}`.
+    """
+    lines: list[str] = []
+    lines.append(
+        f"Week {week} of the {season} {league_name} season is about to "
+        f"kick off Sunday. Preview the slate."
+    )
+    lines.append("")
+
+    lines.append("## Standings going into the week")
+    lines.append("")
+    if not standings:
+        lines.append("_No standings yet._")
+    else:
+        for s in standings:
+            line = (
+                f"- #{s.get('rank')} {s.get('team_name')} "
+                f"({s.get('manager')}) — "
+                f"{s.get('wins')}-{s.get('losses')}, "
+                f"PF {s.get('points_for', 0):.1f}"
+            )
+            lines.append(line)
+    lines.append("")
+
+    lines.append("## World Cup standings")
+    lines.append("")
+    if not wc_standings:
+        lines.append("_WC standings not available — skip the WC angle._")
+    else:
+        for s in wc_standings:
+            lines.append(
+                f"- {s.get('division')} #{s.get('position')}: "
+                f"{s.get('team_name')} ({s.get('wins')}-{s.get('losses')}, "
+                f"{s.get('status')})"
+            )
+    lines.append("")
+
+    lines.append(f"## Week {week} matchups")
+    lines.append("")
+    if not matchup_pairs:
+        lines.append("_No matchups returned by Sleeper for this week._")
+    else:
+        for m in matchup_pairs:
+            a = m.get("team_a", {})
+            b = m.get("team_b", {})
+            lines.append(
+                f"- {a.get('team_name')} ({a.get('wins')}-{a.get('losses')}) "
+                f"vs {b.get('team_name')} ({b.get('wins')}-{b.get('losses')})"
+            )
+            a_starters = a.get("starters") or []
+            b_starters = b.get("starters") or []
+            if a_starters:
+                lines.append(
+                    f"  - {a.get('team_name')} starters (player_ids): "
+                    f"{', '.join(str(s) for s in a_starters[:9])}"
+                )
+            if b_starters:
+                lines.append(
+                    f"  - {b.get('team_name')} starters (player_ids): "
+                    f"{', '.join(str(s) for s in b_starters[:9])}"
+                )
+    lines.append("")
+
+    lines.append("## Recent memories (season context)")
+    lines.append("")
+    if not recent_memories:
+        lines.append("_No prior memories — write a clean slate preview._")
+    else:
+        for mem in recent_memories[:8]:
+            wk = mem.get("week") or "?"
+            txt = mem.get("text", "")
+            lines.append(f"- Week {wk}: {txt}")
+    lines.append("")
+
+    lines.append("## Your job")
+    lines.append("")
+    lines.append(
+        "Write the Week Preview newsletter following the system "
+        "prompt's structure and whitespace rules. Cover all 12 teams "
+        "under Team-by-Team, all 6 matchups under Game by Game, "
+        "anchor every paragraph in a concrete data point, and return "
+        "the JSON envelope from the third system block."
+    )
+    return "\n".join(lines)


### PR DESCRIPTION
Phase 2 build, sliced into 4 ship-in-order PRs:

| PR | What | Status |
|---|---|---|
| **1 (this)** | Prompt + template + test fixture | ready |
| 2 | Cron handler + EventBridge schedule + admin trigger route | next |
| 3 | Admin trigger backend handler | next |
| 4 | iOS picker case + admin trigger card | last |

After this merges + deploys, fire `/admin/email-test-template` with `kind: "week_preview"` and the recipient's sleeper_user_id to preview the layout.

## Body shape
```
# Week N Preview                                  AI
opening paragraph

## World Cup Watch                                AI
who's on the bubble

## Team-by-Team                                   AI x12
one short writeup per manager

## Game by Game                                   AI x6
one blurb per matchup

## Bold Prediction                                AI

[League Pulse standings — HTML]
[World Cup standings — HTML]
```

## Not in scope
Cron handler, EventBridge schedule, admin trigger backend, iOS pieces. All in PRs 2-4.