### PR TITLE
feat(emails): normalize all templates on week_preview styling

### DIFF
--- a/lambdas/common/email_templates/ai_review.py
+++ b/lambdas/common/email_templates/ai_review.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 
 from typing import Any
 
-import markdown as _markdown
-
 from lambdas.common.email_templates.base import (
     wrap_email_html,
     generate_section_title,
     generate_league_badge,
     generate_button,
+    generate_toc,
+    render_markdown_body,
+    extract_h2_sections,
     _escape,
     CHAMPION_GOLD, TEXT_PRIMARY, TEXT_SECONDARY,
     FONT_BODY, XOMPER_URL,
@@ -36,15 +37,14 @@ _REPORT_TYPE_DISPLAY: dict[str, str] = {
 
 
 def render_html(body_markdown: str) -> str:
-    """Convert the markdown body Claude produced into HTML.
-
-    Uses the `markdown` library's `extra` extension so we get tables,
-    fenced code, and definition lists if Claude ever leans on them.
-    Returns an empty string if the body is empty.
-    """
+    """Convert the markdown body Claude produced into HTML using the
+    shared styled renderer from `base.py`. Every email template
+    (week_preview, weekly_recap, ai_review) flows through the same
+    renderer so heading + paragraph styles stay consistent across the
+    inbox. Returns an empty string if the body is empty."""
     if not body_markdown:
         return ""
-    return _markdown.markdown(body_markdown, extensions=["extra"])
+    return render_markdown_body(body_markdown)
 
 
 def _report_type_label(report_type: str) -> str:
@@ -66,6 +66,12 @@ def _wrap_body_content(
 
     league_badge_html = generate_league_badge(league_name) if league_name else ""
 
+    # Pull out the AI body's `## Section` headings for the TOC card.
+    # Only emit the TOC when the body actually has 2+ sections so a
+    # short one-pager doesn't grow an awkward 1-row outline.
+    toc_labels = extract_h2_sections(body_markdown or "")
+    toc_html = generate_toc(toc_labels) if len(toc_labels) >= 2 else ""
+
     return f"""
     {generate_section_title(section_title)}
     {league_badge_html}
@@ -77,6 +83,8 @@ def _wrap_body_content(
             </td>
         </tr>
     </table>
+
+    {toc_html}
 
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>

--- a/lambdas/common/email_templates/base.py
+++ b/lambdas/common/email_templates/base.py
@@ -384,3 +384,165 @@ def _escape(text: str) -> str:
         .replace('"', "&quot;")
         .replace("'", "&#39;")
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared section styling — Phase 3 normalization
+# ---------------------------------------------------------------------------
+#
+# Every email template should use these so the inbox feels consistent:
+# bright red `## main sections` with a thick top divider, gold `### sub`
+# headers, and a numbered Table of Contents up top for any email with
+# 3+ sections. Lifted from `week_preview.py` so the rest of the
+# templates can stop redefining their own helpers.
+# ---------------------------------------------------------------------------
+
+
+def slugify(text: str) -> str:
+    """URL-safe id for anchor links (lowercase alnum + dashes).
+    Keeps the same shape across templates so anchor pills land on the
+    right `id=` regardless of which template emitted the heading."""
+    out: list[str] = []
+    for ch in text.lower():
+        if ch.isalnum():
+            out.append(ch)
+        elif ch in (" ", "-", "_"):
+            out.append("-")
+        elif ch in ("'", "’"):
+            # Skip apostrophes so "Week's recap" becomes "weeks-recap".
+            continue
+    slug = "".join(out).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug or "section"
+
+
+def generate_h2_red_header(label: str) -> str:
+    """Bright-red bar + uppercase label + anchor id. Use this for
+    every `## main section` heading in every email template so the
+    visual rhythm matches the week_preview newsletter."""
+    safe_label = _escape(label)
+    slug = slugify(label)
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 36px 0 12px;">
+        <tr>
+            <td style="height: 4px; background-color: {ACCENT_RED}; line-height: 4px; font-size: 0;">&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="padding: 16px 24px 0;">
+                <h2 id="{slug}" style="margin: 0; font-family: {FONT_DISPLAY}; font-size: 22px; color: {ACCENT_RED}; font-weight: 800; text-transform: uppercase; letter-spacing: 2px;">{safe_label}</h2>
+            </td>
+        </tr>
+    </table>
+    """
+
+
+def generate_h3_gold_header(label: str) -> str:
+    """Gold sub-section heading. Sits under an h2_red on its own line
+    with a bit of breathing room. Anchor id added for consistency
+    with the h2 (TOC implementations can link to either level)."""
+    safe_label = _escape(label)
+    slug = slugify(label)
+    return f"""
+    <h3 id="{slug}" style="margin: 18px 0 6px; font-family: {FONT_DISPLAY}; font-size: 15px; color: {CHAMPION_GOLD}; font-weight: 700;">{safe_label}</h3>
+    """
+
+
+def generate_toc(headings: list[str]) -> str:
+    """Numbered Table of Contents card. Each row anchor-links to its
+    section. Anchor behavior varies by client (Gmail strips jumps,
+    Apple Mail navigates) — either way it's a visible outline up top."""
+    if not headings:
+        return ""
+    rows = ""
+    for idx, label in enumerate(headings, start=1):
+        slug = slugify(label)
+        safe_label = _escape(label)
+        bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
+        rows += f"""
+        <tr>
+            <td style="padding: 10px 14px; background-color: {bg};">
+                <a href="#{slug}" style="text-decoration: none; color: {TEXT_PRIMARY}; font-family: {FONT_BODY}; font-size: 14px; font-weight: 600;">
+                    <span style="display: inline-block; width: 26px; color: {ACCENT_RED}; font-weight: 800;">{idx:02d}</span>
+                    {safe_label}
+                </a>
+            </td>
+        </tr>
+        """
+    return f"""
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+        <tr>
+            <td style="padding: 0 24px 24px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
+                       style="border: 1px solid {ACCENT_RED}; border-radius: 10px; overflow: hidden;">
+                    <tr style="background-color: {DARK_NAVY};">
+                        <td style="padding: 14px 14px 12px; border-bottom: 1px solid {ACCENT_RED};">
+                            <div style="font-family: {FONT_DISPLAY}; font-size: 10px; color: {TEXT_MUTED}; letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 2px;">Newsletter</div>
+                            <div style="font-family: {FONT_DISPLAY}; font-size: 17px; color: {ACCENT_RED}; font-weight: 800; text-transform: uppercase; letter-spacing: 2px;">Table of Contents</div>
+                        </td>
+                    </tr>
+                    {rows}
+                </table>
+            </td>
+        </tr>
+    </table>
+    """
+
+
+def render_markdown_body(md: str) -> str:
+    """Turn AI markdown bodies into the same styled HTML week_preview
+    uses. Handles `#`/`##`/`###` headings, paragraphs, `**bold**`,
+    blockquotes. The dependency-free renderer keeps the lambda layer
+    light + ensures heading styles match `generate_h2_red_header` and
+    `generate_h3_gold_header` exactly (no drift from a generic
+    markdown library)."""
+    if not md or not md.strip():
+        return ""
+    blocks = [b.strip() for b in md.split("\n\n") if b.strip()]
+    return "\n".join(_render_block(b) for b in blocks)
+
+
+def extract_h2_sections(md: str) -> list[str]:
+    """Return every `## Heading` label in source order so callers can
+    feed the list into `generate_toc`."""
+    sections: list[str] = []
+    for line in md.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## ") and not stripped.startswith("### "):
+            sections.append(stripped[3:].strip())
+    return sections
+
+
+def _render_block(block: str) -> str:
+    if block.startswith("### "):
+        return generate_h3_gold_header(block[4:].strip())
+    if block.startswith("## "):
+        return generate_h2_red_header(block[3:].strip())
+    if block.startswith("# "):
+        text = _inline_bold(block[2:].strip())
+        return f'<h1 style="margin: 8px 0 12px; font-family: {FONT_DISPLAY}; font-size: 22px; color: {TEXT_PRIMARY}; font-weight: 700;">{text}</h1>'
+    if block.startswith("> "):
+        text = _inline_bold(block[2:].strip())
+        return f'<blockquote style="margin: 8px 0; padding: 8px 14px; border-left: 3px solid {CHAMPION_GOLD}; color: {TEXT_SECONDARY}; font-style: italic;">{text}</blockquote>'
+    text = _inline_bold(block.replace("\n", "<br/>"))
+    return f'<p style="margin: 0 0 10px; line-height: 1.55;">{text}</p>'
+
+
+def _inline_bold(text: str) -> str:
+    """Escape + render `**bold**` spans. Naive scan — handles the AI's
+    standard usage."""
+    escaped = _escape(text)
+    out = ""
+    i = 0
+    while i < len(escaped):
+        if escaped[i:i + 2] == "**":
+            end = escaped.find("**", i + 2)
+            if end == -1:
+                out += escaped[i:]
+                break
+            out += f'<strong style="color: {TEXT_PRIMARY};">{escaped[i + 2:end]}</strong>'
+            i = end + 2
+        else:
+            out += escaped[i]
+            i += 1
+    return out

--- a/lambdas/common/email_templates/week_preview.py
+++ b/lambdas/common/email_templates/week_preview.py
@@ -18,6 +18,10 @@ from lambdas.common.email_templates.base import (
     generate_section_title,
     generate_league_badge,
     generate_button,
+    generate_h2_red_header,
+    generate_toc,
+    render_markdown_body,
+    extract_h2_sections,
     _escape,
     CHAMPION_GOLD, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
     DARK_NAVY, SURFACE_LIGHT, SUCCESS_GREEN, ACCENT_RED,
@@ -56,13 +60,13 @@ def generate_week_preview_email(
     # TOC reflects EVERY section of the email, including ones rendered
     # outside the markdown body. Each pill links to an `id=` slug
     # injected on the matching header below.
-    h2_sections = list(_extract_h2_sections(body_markdown or ""))
+    h2_sections = list(extract_h2_sections(body_markdown or ""))
     if standings:
         h2_sections.append("League Pulse")
     if wc_divisions:
         h2_sections.append("World Cup Standings")
-    toc_html = _toc_section(h2_sections) if h2_sections else ""
-    body_html = _markdown_to_email_html(body_markdown or "")
+    toc_html = generate_toc(h2_sections) if h2_sections else ""
+    body_html = render_markdown_body(body_markdown or "")
 
     standings_html = _standings_section(standings) if standings else ""
     wc_html = _wc_section(wc_divisions) if wc_divisions else ""
@@ -148,161 +152,10 @@ def generate_week_preview_email_plain_text(
 
 
 # ---------------------------------------------------------------------------
-# Lightweight markdown → HTML pass tailored to the AI body's shape.
-#
-# We DON'T pull a real markdown parser into the lambda layer (extra
-# weight, more deps to keep on cp313). The AI's output is constrained
-# to a small subset by the prompt — `#`/`##`/`###` headings, blank-line
-# paragraphs, `**bold**`, list dashes — so a 20-line stub covers it.
+# All markdown rendering + TOC + h2 helpers now live in base.py
+# (`render_markdown_body`, `generate_h2_red_header`, `generate_toc`,
+# `extract_h2_sections`) so every email template can share them.
 # ---------------------------------------------------------------------------
-
-
-def _markdown_to_email_html(md: str) -> str:
-    if not md.strip():
-        return ""
-    blocks = [b.strip() for b in md.split("\n\n") if b.strip()]
-    out_parts: list[str] = []
-    for block in blocks:
-        out_parts.append(_render_block(block))
-    return "\n".join(out_parts)
-
-
-def _render_block(block: str) -> str:
-    # Headings
-    if block.startswith("### "):
-        raw = block[4:].strip()
-        text = _inline(raw)
-        return f'<h3 style="margin: 18px 0 6px; font-family: {FONT_DISPLAY}; font-size: 15px; color: {CHAMPION_GOLD}; font-weight: 700;">{text}</h3>'
-    if block.startswith("## "):
-        raw = block[3:].strip()
-        # Reuse the HTML-side h2 helper so AI-body sections and HTML
-        # sections (standings, WC) look identical. `_h2_section_header`
-        # injects the same red bar + uppercase title + id anchor.
-        return _h2_section_header(raw)
-    if block.startswith("# "):
-        text = _inline(block[2:].strip())
-        return f'<h1 style="margin: 8px 0 12px; font-family: {FONT_DISPLAY}; font-size: 22px; color: {TEXT_PRIMARY}; font-weight: 700;">{text}</h1>'
-    # Quote
-    if block.startswith("> "):
-        text = _inline(block[2:].strip())
-        return f'<blockquote style="margin: 8px 0; padding: 8px 14px; border-left: 3px solid {CHAMPION_GOLD}; color: {TEXT_SECONDARY}; font-style: italic;">{text}</blockquote>'
-    # Plain paragraph — inline bold + bare line
-    text = _inline(block.replace("\n", "<br/>"))
-    return f'<p style="margin: 0 0 10px; line-height: 1.55;">{text}</p>'
-
-
-# ---------------------------------------------------------------------------
-# Table of contents + anchor helpers
-# ---------------------------------------------------------------------------
-
-
-def _extract_h2_sections(md: str) -> list[str]:
-    """Return the raw label for each `## Heading` in source order.
-    Used to build both the TOC pills and the `id=` slugs on the
-    rendered h2 tags."""
-    sections: list[str] = []
-    for line in md.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("## ") and not stripped.startswith("### "):
-            sections.append(stripped[3:].strip())
-    return sections
-
-
-def _slug(text: str) -> str:
-    """URL-safe id for anchor links. Lowercase, alphanumerics + dashes."""
-    out: list[str] = []
-    for ch in text.lower():
-        if ch.isalnum():
-            out.append(ch)
-        elif ch in (" ", "-", "_"):
-            out.append("-")
-    slug = "".join(out).strip("-")
-    while "--" in slug:
-        slug = slug.replace("--", "-")
-    return slug or "section"
-
-
-def _toc_section(headings: list[str]) -> str:
-    """Numbered Table of Contents. Each row anchor-links to its section
-    (some clients navigate, some don't — best-effort across the matrix).
-    Either way it acts as a real TOC the reader can scan up-top before
-    committing to a long email."""
-    if not headings:
-        return ""
-    rows = ""
-    for idx, label in enumerate(headings, start=1):
-        slug = _slug(label)
-        safe_label = _escape(label)
-        bg = SURFACE_LIGHT if (idx % 2 == 1) else "transparent"
-        rows += f"""
-        <tr>
-            <td style="padding: 10px 14px; background-color: {bg};">
-                <a href="#{slug}" style="text-decoration: none; color: {TEXT_PRIMARY}; font-family: {FONT_BODY}; font-size: 14px; font-weight: 600;">
-                    <span style="display: inline-block; width: 26px; color: {ACCENT_RED}; font-weight: 800;">{idx:02d}</span>
-                    {safe_label}
-                </a>
-            </td>
-        </tr>
-        """
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-        <tr>
-            <td style="padding: 0 24px 24px;">
-                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"
-                       style="border: 1px solid {ACCENT_RED}; border-radius: 10px; overflow: hidden;">
-                    <tr style="background-color: {DARK_NAVY};">
-                        <td style="padding: 14px 14px 12px; border-bottom: 1px solid {ACCENT_RED};">
-                            <div style="font-family: {FONT_DISPLAY}; font-size: 10px; color: {TEXT_MUTED}; letter-spacing: 1.5px; text-transform: uppercase; margin-bottom: 2px;">Newsletter</div>
-                            <div style="font-family: {FONT_DISPLAY}; font-size: 17px; color: {ACCENT_RED}; font-weight: 800; text-transform: uppercase; letter-spacing: 2px;">Table of Contents</div>
-                        </td>
-                    </tr>
-                    {rows}
-                </table>
-            </td>
-        </tr>
-    </table>
-    """
-
-
-def _h2_section_header(label: str) -> str:
-    """Red banner with a thick top divider, a number badge, and the
-    section label. Bigger landmark than the AI-body inline `## ...`
-    treatment — used by both `_render_block` and the HTML-side
-    section helpers so every section looks the same."""
-    safe_label = _escape(label)
-    slug = _slug(label)
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 36px 0 12px;">
-        <tr>
-            <td style="height: 4px; background-color: {ACCENT_RED}; line-height: 4px; font-size: 0;">&nbsp;</td>
-        </tr>
-        <tr>
-            <td style="padding: 16px 24px 0;">
-                <h2 id="{slug}" style="margin: 0; font-family: {FONT_DISPLAY}; font-size: 22px; color: {ACCENT_RED}; font-weight: 800; text-transform: uppercase; letter-spacing: 2px;">{safe_label}</h2>
-            </td>
-        </tr>
-    </table>
-    """
-
-
-def _inline(text: str) -> str:
-    # Escape first, then re-introduce bold spans.
-    escaped = _escape(text)
-    # Naive **bold** pass — handles the AI's standard `**X**` usage.
-    out = ""
-    i = 0
-    while i < len(escaped):
-        if escaped[i:i + 2] == "**":
-            end = escaped.find("**", i + 2)
-            if end == -1:
-                out += escaped[i:]
-                break
-            out += f'<strong style="color: {TEXT_PRIMARY};">{escaped[i + 2:end]}</strong>'
-            i = end + 2
-        else:
-            out += escaped[i]
-            i += 1
-    return out
 
 
 def _standings_section(
@@ -321,7 +174,7 @@ def _standings_section(
         </tr>
         """
     return f"""
-    {_h2_section_header("League Pulse")}
+    {generate_h2_red_header("League Pulse")}
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
             <td style="padding: 0 24px 16px;">
@@ -375,7 +228,7 @@ def _wc_section(
         </tr>
         """
     return f"""
-    {_h2_section_header("World Cup Standings")}
+    {generate_h2_red_header("World Cup Standings")}
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         {div_blocks}
     </table>

--- a/lambdas/common/email_templates/weekly_recap.py
+++ b/lambdas/common/email_templates/weekly_recap.py
@@ -10,6 +10,8 @@ from lambdas.common.email_templates.base import (
     generate_section_title,
     generate_league_badge,
     generate_button,
+    generate_h2_red_header,
+    generate_toc,
     _escape,
     CHAMPION_GOLD, TEXT_PRIMARY, TEXT_SECONDARY, TEXT_MUTED,
     DARK_NAVY, SURFACE_LIGHT, SUCCESS_GREEN, ACCENT_RED,
@@ -101,6 +103,18 @@ def generate_weekly_recap_email(
     bracket_html = _bracket_section(bracket_rounds) if (bracket_rounds and week >= 12) else ""
     wc_html = _worldcup_section(wc_personal, wc_divisions) if (wc_personal or wc_divisions) else ""
 
+    # Build the TOC from whatever sections actually rendered. Match the
+    # exact labels we pass into generate_h2_red_header() so the anchor
+    # slugs line up.
+    toc_labels: list[str] = ["This week's scores"]
+    if standings_html:
+        toc_labels.append("Standings")
+    if bracket_html:
+        toc_labels.append("Playoff Bracket")
+    if wc_html:
+        toc_labels.append("World Cup")
+    toc_html = generate_toc(toc_labels)
+
     content = f"""
     {generate_section_title(f"Week {week} Recap")}
     {generate_league_badge(league_name) if league_name else ""}
@@ -123,7 +137,9 @@ def generate_weekly_recap_email(
         </tr>
     </table>
 
-    {_section_header("This week's scores")}
+    {toc_html}
+
+    {generate_h2_red_header("This week's scores")}
 
     <!-- This week's scoreboard -->
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
@@ -258,22 +274,10 @@ def generate_weekly_recap_email_plain_text(
 
 
 # ---------------------------------------------------------------------------
-# Section renderers — HTML helpers kept private to this module
+# Section renderers — HTML helpers kept private to this module.
+# Header rendering (h2 red + h3 gold + TOC) lives in base.py and is
+# shared across every template.
 # ---------------------------------------------------------------------------
-
-
-def _section_header(label: str) -> str:
-    """Inline section divider with uppercase label. Matches the
-    `generate_section_title` look-and-feel but smaller (sub-sections)."""
-    return f"""
-    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-        <tr>
-            <td style="padding: 0 24px 8px; font-family: {FONT_DISPLAY}; font-size: 11px; color: {TEXT_MUTED}; letter-spacing: 1px; text-transform: uppercase;">
-                {_escape(label)}
-            </td>
-        </tr>
-    </table>
-    """
 
 
 def _standings_section(
@@ -296,7 +300,7 @@ def _standings_section(
         </tr>
         """
     return f"""
-    {_section_header("Standings")}
+    {generate_h2_red_header("Standings")}
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
             <td style="padding: 0 24px 16px;">
@@ -359,7 +363,7 @@ def _bracket_section(
         </tr>
         """
     return f"""
-    {_section_header("Playoff Bracket")}
+    {generate_h2_red_header("Playoff Bracket")}
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         {blocks}
     </table>
@@ -462,7 +466,7 @@ def _worldcup_section(
         return ""
 
     return f"""
-    {_section_header("World Cup")}
+    {generate_h2_red_header("World Cup")}
     {personal_block}
     {full_block}
     """


### PR DESCRIPTION
Every email template now uses the same red h2 dividers, gold sub-headers, and numbered TOC. Lifted from week_preview into base.py and applied to weekly_recap + ai_review (the other two multi-section templates). Single-section emails (lineup_not_set, rule_*, taxi_*) keep their existing chrome since the TOC doesn't add value there.