### PR TITLE
#89 fix: offseason guard on all game-dependent notifs

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -89,6 +89,7 @@ jobs:
             tests/test_claude_helper.py \
             tests/test_ai_reports_store.py \
             tests/test_season_resolver.py \
+            tests/test_season_guard.py \
             -v --cov=lambdas/common
 
   test-lambdas:

--- a/lambdas/common/season_guard.py
+++ b/lambdas/common/season_guard.py
@@ -1,0 +1,78 @@
+"""
+season_guard helper
+====================
+Shared offseason guard for the game-dependent scheduled notif lambdas.
+
+EventBridge fires the weekly recap, close-game alert, lineup-not-set,
+and world-cup movement notifs on fixed cron expressions year-round.
+None of them make sense once the NFL regular season ends — recapping a
+week that was never played, alerting on lineups for games that don't
+exist. Before this guard, the only thing stopping an offseason send was
+the admin cron toggle, which means a human had to remember to flip every
+notif off in February and back on in September. They didn't, so a
+"Week 1 recap" went out in June.
+
+This guard makes offseason suppression automatic, mirroring the
+pre-flight already baked into `weekly_orchestrator` /
+`week_preview_orchestrator` (the AI-newsletter path). Each handler calls
+`offseason_skip(nfl_state, LAMBDA_CRON_KEY, force=...)` immediately after
+fetching nfl_state and returns the result if it's truthy.
+
+Safety posture matches `cron_settings`: best-effort. If `season_type` is
+blank/unknown we DO NOT skip — better to send than to wrongly suppress a
+real in-season notification on a transient Sleeper hiccup. `force=True`
+(manual/backfill invokes carrying an explicit week or `force` flag)
+bypasses the guard entirely so testing + historical backfill still work.
+"""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from lambdas.common.constants import AI_REVIEW_WEEKLY_OK_SEASON_TYPES
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import success_response
+
+log = get_logger(__file__)
+
+
+def is_offseason(nfl_state: dict[str, Any]) -> bool:
+    """True when NFL `season_type` is known AND not regular/post.
+
+    Blank/unknown season_type returns False (don't suppress on a
+    transient read failure) — same posture as `cron_settings`.
+    """
+    season_type = (nfl_state.get("season_type") or "").lower()
+    return bool(season_type) and season_type not in AI_REVIEW_WEEKLY_OK_SEASON_TYPES
+
+
+def offseason_skip(
+    nfl_state: dict[str, Any],
+    handler_name: str,
+    *,
+    force: bool = False,
+) -> Optional[dict[str, Any]]:
+    """Return a `skipped` success_response when out of season, else None.
+
+    - `force=True` bypasses the guard (manual/backfill invokes).
+    - Logs the skip at info so the absence of an offseason send is
+      visible in CloudWatch without looking like an error.
+    """
+    if force:
+        return None
+    if not is_offseason(nfl_state):
+        return None
+
+    season_type = (nfl_state.get("season_type") or "").lower()
+    log.info(
+        f"{handler_name}: season_type={season_type!r} not in "
+        f"{AI_REVIEW_WEEKLY_OK_SEASON_TYPES} — skipping offseason fire"
+    )
+    return success_response(
+        {
+            "Success": True,
+            "skipped": True,
+            "reason": "offseason",
+            "season_type": season_type,
+        },
+        is_api=False,
+    )

--- a/lambdas/notif_close_game_alert/handler.py
+++ b/lambdas/notif_close_game_alert/handler.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from lambdas.common.admin_only_filter import filter_to_admin_only
 from lambdas.common.cron_settings import get_cron_setting
+from lambdas.common.season_guard import offseason_skip
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -67,7 +68,14 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
 
     league_id = league_row["league_id"]
     nfl_state = get_nfl_state()
-    week = int(event.get("week") if isinstance(event, dict) and event.get("week") else nfl_state.get("week", 1))
+    week_override = event.get("week") if isinstance(event, dict) else None
+
+    # Offseason guard — no live games to alert on once the season ends.
+    skip = offseason_skip(nfl_state, LAMBDA_CRON_KEY, force=bool(week_override))
+    if skip:
+        return skip
+
+    week = int(week_override if week_override else nfl_state.get("week", 1))
 
     log.info(f"Scanning live scores for week {week} in league {league_id}")
 

--- a/lambdas/notif_lineup_not_set/handler.py
+++ b/lambdas/notif_lineup_not_set/handler.py
@@ -13,6 +13,7 @@ A manager with no issues never gets pinged.
 from typing import Any
 from lambdas.common.admin_only_filter import filter_to_admin_only
 from lambdas.common.cron_settings import get_cron_setting
+from lambdas.common.season_guard import offseason_skip
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -71,7 +72,14 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     league_name = league_row.get("league_name", "League")
 
     nfl_state = get_nfl_state()
-    week = int(event.get("week") if isinstance(event, dict) and event.get("week") else nfl_state.get("week", 1))
+    week_override = event.get("week") if isinstance(event, dict) else None
+
+    # Offseason guard — no games means no lineups to nag about.
+    skip = offseason_skip(nfl_state, LAMBDA_CRON_KEY, force=bool(week_override))
+    if skip:
+        return skip
+
+    week = int(week_override if week_override else nfl_state.get("week", 1))
 
     log.info(f"Auditing lineups for week {week} in league {league_id}")
 

--- a/lambdas/notif_weekly_recap/handler.py
+++ b/lambdas/notif_weekly_recap/handler.py
@@ -21,6 +21,7 @@ import requests
 from lambdas.common.admin_only_filter import filter_to_admin_only
 from lambdas.common.constants import TOTAL_REGULAR_WEEKS
 from lambdas.common.cron_settings import get_cron_setting
+from lambdas.common.season_guard import offseason_skip
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -86,6 +87,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     nfl_state = get_nfl_state()
     current_week = nfl_state.get("week", 1)
     week_override = event.get("week") if isinstance(event, dict) else None
+
+    # Offseason guard (admin-cron-settings is NOT enough — a human has to
+    # remember to toggle it). A manual week override bypasses so backfill
+    # still works. Without this, the Tue 9am cron recapped "Week 1" in
+    # June because nfl_state.week fell back to 1.
+    skip = offseason_skip(nfl_state, LAMBDA_CRON_KEY, force=week_override is not None)
+    if skip:
+        return skip
+
     target_week = int(week_override) if week_override else max(current_week - 1, 1)
 
     log.info(f"Recapping week {target_week} for league {league_id} ({league_name})")

--- a/lambdas/notif_worldcup_movement/handler.py
+++ b/lambdas/notif_worldcup_movement/handler.py
@@ -36,6 +36,7 @@ from boto3.dynamodb.conditions import Key
 
 from lambdas.common.admin_only_filter import filter_to_admin_only
 from lambdas.common.cron_settings import get_cron_setting
+from lambdas.common.season_guard import offseason_skip
 from lambdas.common.logger import get_logger
 from lambdas.common.errors import handle_errors
 from lambdas.common.utility_helpers import success_response
@@ -48,6 +49,7 @@ from lambdas.common.sleeper_helper import (
     get_sleeper_league_rosters,
     get_sleeper_league_users,
     get_sleeper_league_matchups,
+    get_nfl_state,
 )
 from lambdas.common.sns_helper import send_push_to_users
 from lambdas.common.push_templates import (
@@ -100,6 +102,15 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     if not league_row.get("has_taxi") or not league_row.get("is_dynasty"):
         log.info("Active league not World-Cup eligible (needs has_taxi + is_dynasty). Skipping.")
         return success_response({"sent": 0, "reason": "not world-cup eligible"}, is_api=False)
+
+    # Offseason guard — standings don't move once the season ends. A
+    # manual week/games_remaining override bypasses for backfill/testing.
+    _override = isinstance(event, dict) and (
+        event.get("week") is not None or event.get("games_remaining") is not None
+    )
+    skip = offseason_skip(get_nfl_state(), LAMBDA_CRON_KEY, force=bool(_override))
+    if skip:
+        return skip
 
     head_league_id = league_row["league_id"]
     games_remaining = int(

--- a/sql/2026-06-14-cron-seed-week-preview.sql
+++ b/sql/2026-06-14-cron-seed-week-preview.sql
@@ -1,0 +1,19 @@
+-- 2026-06-14 — seed the missing notif_week_preview cron key
+-- ==========================================================
+-- admin_cron_settings_migration.sql seeded 5 rows but there are 6
+-- cron-keyed notif lambdas. notif_week_preview was never seeded, so it
+-- never appears in the admin cron-settings list and is therefore
+-- un-toggleable from the iOS/web admin UI — it silently runs on the
+-- get_cron_setting() safe default (enabled=True). This backfills the
+-- missing row so every scheduled notif is visible + controllable.
+--
+-- Idempotent: `on conflict do nothing` leaves an existing row (and any
+-- admin toggle) untouched.
+--
+-- Apply: run against the Supabase project SQL editor (service role).
+--   select cron_key, enabled from public.admin_cron_settings order by cron_key;
+--   -- expect 6 rows after this runs.
+
+insert into public.admin_cron_settings (cron_key, enabled, test_mode, description) values
+    ('notif_week_preview', true, false, 'Week preview newsletter — Wed 9am ET')
+on conflict (cron_key) do nothing;

--- a/tests/test_season_guard.py
+++ b/tests/test_season_guard.py
@@ -1,0 +1,50 @@
+"""
+Tests for `lambdas.common.season_guard`.
+
+Locks the offseason suppression that keeps the four game-dependent
+scheduled notifs (weekly recap, close-game, lineup-not-set, world-cup
+movement) from firing year-round. Regression target: a "Week 1 recap"
+that went out in June because no guard existed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lambdas.common.season_guard import is_offseason, offseason_skip
+
+
+class TestIsOffseason:
+    @pytest.mark.parametrize("season_type", ["regular", "post", "REGULAR", "Post"])
+    def test_in_season_is_false(self, season_type):
+        assert is_offseason({"season_type": season_type}) is False
+
+    @pytest.mark.parametrize("season_type", ["off", "pre", "OFF", "Pre"])
+    def test_out_of_season_is_true(self, season_type):
+        assert is_offseason({"season_type": season_type}) is True
+
+    def test_blank_or_unknown_is_false(self):
+        # Best-effort: never suppress on a transient/blank read.
+        assert is_offseason({}) is False
+        assert is_offseason({"season_type": ""}) is False
+        assert is_offseason({"season_type": None}) is False
+
+
+class TestOffseasonSkip:
+    def test_in_season_returns_none(self):
+        assert offseason_skip({"season_type": "regular"}, "notif_weekly_recap") is None
+
+    def test_offseason_returns_skip_response(self):
+        resp = offseason_skip({"season_type": "off"}, "notif_weekly_recap")
+        assert resp is not None
+        # is_api=False → body is the raw dict, not a JSON string.
+        body = resp["body"]
+        assert body["skipped"] is True
+        assert body["reason"] == "offseason"
+        assert body["season_type"] == "off"
+
+    def test_force_bypasses_guard(self):
+        # Manual/backfill invoke with an explicit week → never suppressed.
+        assert offseason_skip({"season_type": "off"}, "notif_weekly_recap", force=True) is None
+
+    def test_blank_season_type_does_not_skip(self):
+        assert offseason_skip({}, "notif_weekly_recap") is None


### PR DESCRIPTION
Closes #89

## The fire
A **Week 1 recap** email went out **June 9 (Tuesday)** in the offseason. `notif_weekly_recap` (Tue 9am ET) has no offseason guard — it read `nfl_state.week`, computed `max(week-1,1)=1`, and recapped a week never played. The cron toggle was the only thing that could stop it.

## Root cause + scope
All **four** game-dependent scheduled notifs lacked a `season_type` guard:
`notif_weekly_recap`, `notif_close_game_alert`, `notif_lineup_not_set`, `notif_worldcup_movement`. The AI-newsletter path already guards offseason via its orchestrators; these never got the same treatment.

Secondary: the cron-settings migration seeded **5 of 6** keys — `notif_week_preview` was missing, so it never appeared in the admin list and was un-toggleable.

## Changes
- **New** `lambdas/common/season_guard.py` — `is_offseason()` / `offseason_skip()`, reusing `AI_REVIEW_WEEKLY_OK_SEASON_TYPES = ("regular","post")`. Best-effort (blank `season_type` does NOT suppress — same posture as `cron_settings`). `force=True` bypass for manual/backfill invokes carrying an explicit week.
- Guard applied to all four handlers immediately after `get_nfl_state()`.
- **New migration** `sql/2026-06-14-cron-seed-week-preview.sql` — idempotent `insert ... on conflict do nothing` seeding the missing `notif_week_preview` row.

## Deploy steps (after merge)
1. Backend deploy (GitHub Actions) ships the lambda code.
2. **Apply the SQL migration** in the Supabase SQL editor (service role) — `select count(*)` should read **6** after.

## Test plan
- [x] 13 new `season_guard` unit cases (in-season passes, off/pre skips, blank doesn't suppress, force bypasses)
- [x] cron-settings suite green (47 local total)
- [ ] CI (py3.13) runs the full suite incl. handler tests that import email templates
- [ ] Post-deploy: next Tue 9am — confirm `notif_weekly_recap` logs `skipped offseason`, no email

## Follow-up (separate)
Replace passive `test_mode` with an on-demand "send me a test now" action — likely wire cron notifs into the existing Test Email admin screen. Draft+approval flow = overkill (per Dom).