### PR TITLE
#89 fix: week_preview cron toggle + resilient deploy precheck

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -220,17 +220,23 @@ jobs:
 
           echo "Deploying code for $FUNCTION_NAME"
 
-          # Wait for any in-flight infra updates to settle before our code push.
-          # Terraform in xomper-infrastructure may still be creating/updating
-          # this lambda concurrently — pushing code while it's in `Pending`
-          # state hits ResourceConflictException. `function-active` waits up
-          # to 10 minutes for the function to reach Active state. If the
-          # lambda doesn't exist yet (terraform hasn't run), bail loudly so
-          # the human can rerun once terraform finishes.
-          if ! aws lambda wait function-active --function-name $FUNCTION_NAME --region $AWS_REGION 2>/dev/null; then
-            echo "::error::Lambda $FUNCTION_NAME not yet Active — terraform may still be applying. Rerun this job after the terraform workflow completes."
+          # Confirm the function exists; bail loudly ONLY if it genuinely
+          # doesn't (terraform hasn't created it yet). We must NOT hard-gate
+          # on State=Active: a function that's `Inactive` (offseason — not
+          # invoked in 2+ weeks, AWS idles it) or `Failed` (left over from a
+          # prior interrupted update) would deadlock here forever, because the
+          # very `update-function-code` below is what reactivates/recovers it.
+          STATE=$(aws lambda get-function-configuration \
+            --function-name $FUNCTION_NAME --region $AWS_REGION \
+            --query 'State' --output text 2>/dev/null || echo "MISSING")
+          if [ "$STATE" = "MISSING" ]; then
+            echo "::error::Lambda $FUNCTION_NAME does not exist — terraform may not have created it yet. Rerun after the terraform workflow completes."
             exit 1
           fi
+          echo "Current state: $STATE — proceeding (update reactivates Inactive / recovers Failed)."
+          # Best-effort settle if mid-update (Pending). Never hard-fail here —
+          # the ResourceConflictException retry loop below is the real guard.
+          aws lambda wait function-active --function-name $FUNCTION_NAME --region $AWS_REGION 2>/dev/null || true
 
           # Retry the code update on ResourceConflictException up to 3 times
           # with backoff — covers the narrow window where terraform has

--- a/lambdas/api_admin_cron_settings_update/handler.py
+++ b/lambdas/api_admin_cron_settings_update/handler.py
@@ -52,6 +52,7 @@ _ALLOWED_CRON_KEYS: tuple[str, ...] = (
     "notif_close_game_alert",
     "notif_worldcup_movement",
     "notif_ai_review_weekly",
+    "notif_week_preview",
 )
 
 

--- a/lambdas/notif_close_game_alert/handler.py
+++ b/lambdas/notif_close_game_alert/handler.py
@@ -1,6 +1,9 @@
 """
 Notification — Close Game Alert (scheduled, Sunday + Monday primetime)
 ======================================================================
+Offseason guard added (#89); redeploy nudged through the hardened
+deploy precheck that no longer dead-locks on Inactive functions.
+
 At Sun 8pm ET and Mon 8pm ET, scans live matchup scores for the
 active league. For any matchup where the score is within 10 points,
 pushes both managers an alert.


### PR DESCRIPTION
Follow-up to #90.

## 1. Can't turn off Week Preview newsletter (admin)
The cron-settings **update** endpoint validates `cron_key` against a hardcoded `_ALLOWED_CRON_KEYS` that only had the original 5 keys. `notif_week_preview` (seeded by the 2026-06-14 migration) was missing, so toggling it returned `400 Unknown cron_key`. The web UI optimistically flips the toggle then rolls back on the error — exactly the "flips off → spinner → flips back on" symptom. **Fix:** added `notif_week_preview` to the allowlist.

## 2. close_game_alert deploy deadlock
`deploy-backend` hard-failed when a lambda wasn't `State=Active` before the code push. An **Inactive** function (offseason — AWS idles functions not invoked in ~2 weeks) or a **Failed** one deadlocks, because the `update-function-code` that would reactivate/recover it never runs. `notif_close_game_alert` was stuck across 5 reruns. **Fix:** check existence (bail only if MISSING), best-effort settle, then let the existing ResourceConflictException retry loop handle Pending. Update reactivates Inactive / recovers Failed.

## 3. Redeploy nudge
Comment bump on `notif_close_game_alert` so this push redeploys it (carrying its #89 offseason guard) through the hardened precheck.

## Test plan
- [ ] Deploy succeeds incl. `deploy-changed-lambdas (notif_close_game_alert)` — GREEN this time
- [ ] Admin → Cron Settings → toggle Week Preview off → it STAYS off (no rollback)
- [ ] Other cron toggles still work