### PR TITLE
Serve player metadata from the warehouse

### DIFF
--- a/lambdas/api_players_list/handler.py
+++ b/lambdas/api_players_list/handler.py
@@ -1,0 +1,81 @@
+"""
+API — Player metadata
+=====================
+GET /players/list
+
+Returns the slimmed player map keyed by Sleeper player id, in the same shape
+the frontend already expects from Sleeper's own endpoint.
+
+Why this exists: `https://api.sleeper.app/v1/players/nfl` is **14.6 MB**, and
+the app downloads all of it on every session to resolve names and positions.
+This table carries only the fields the Angular source actually reads, for the
+positions the app values — roughly 4,300 players instead of every person
+Sleeper has ever had on a roster.
+
+The response is deliberately the same {playerId: {...}} map rather than a
+list, so PlayerService can swap its source without reshaping anything
+downstream.
+"""
+from decimal import Decimal
+from typing import Any
+
+import boto3
+
+from lambdas.common.constants import PLAYERS_TABLE_NAME
+from lambdas.common.errors import handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import success_response
+
+HANDLER = "api_players_list"
+log = get_logger(HANDLER)
+
+
+def _scan_all(table: Any) -> list[dict[str, Any]]:
+    """Full scan, following pagination.
+
+    A scan is the right call here and not a smell: the endpoint returns the
+    whole table by design, the table is ~4,300 small items, and it is rewritten
+    wholesale by the nightly ingest. A query would need a partition key that
+    exists only to avoid scanning something we always want in full.
+    """
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {}
+    while True:
+        page = table.scan(**kwargs)
+        items.extend(page.get("Items", []))
+        last = page.get("LastEvaluatedKey")
+        if not last:
+            return items
+        kwargs["ExclusiveStartKey"] = last
+
+
+def _plain(value: Any) -> Any:
+    """DynamoDB hands numbers back as Decimal, which json cannot encode.
+
+    Integral values become int so `age: 25` does not serialise as `25.0`;
+    anything fractional stays a float rather than being truncated to an int.
+    """
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    return value
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    table = boto3.resource("dynamodb").Table(PLAYERS_TABLE_NAME)
+    items = _scan_all(table)
+
+    players: dict[str, dict[str, Any]] = {}
+    for item in items:
+        player_id = item.get("playerId")
+        if not player_id:
+            continue
+        record = {
+            key: _plain(value)
+            for key, value in item.items()
+            if key != "playerId"
+        }
+        players[str(player_id)] = record
+
+    log.info(f"players: returning {len(players)} from {PLAYERS_TABLE_NAME}")
+    return success_response({"count": len(players), "players": players})

--- a/lambdas/warehouse_ingest/handler.py
+++ b/lambdas/warehouse_ingest/handler.py
@@ -71,13 +71,28 @@ EPHEMERAL_DIR = "/tmp"
 
 VALUED_POSITIONS = ("QB", "RB", "WR", "TE", "K", "DEF")
 
-# Fields the frontend actually needs. The full dump is ~5 MB; this is the
-# subset that drives names, positions and the cross-platform id crosswalk.
+# Fields the frontend actually reads.
+#
+# Sleeper's /players/nfl dump is 14.6 MB and the browser downloads all of it
+# every session. This is the subset the app touches, counted from usage across
+# the Angular source rather than guessed: position (68 references), status
+# (53), team (49), first/last name (12 each), number, years_exp,
+# injury_status, age. Plus the espn/yahoo ids, which nothing renders but which
+# are the cross-platform crosswalk.
+#
+# Adding a field here is cheap; omitting one the UI reads is not. An earlier
+# version of this list left out status, injury_status, age, years_exp and
+# number, which would have blanked those in every player view.
 PLAYER_FIELDS = (
     "first_name",
     "last_name",
     "position",
     "team",
+    "status",
+    "injury_status",
+    "age",
+    "years_exp",
+    "number",
     "espn_id",
     "yahoo_id",
     "search_rank",


### PR DESCRIPTION
Sleeper’s `/players/nfl` is **14.6 MB** and the app downloads all of it on every session, just to resolve names and positions. `GET /players/list` returns the same `{playerId: {...}}` map from the warehouse table instead — about **4,300 players** rather than everyone Sleeper has ever had on a roster.

Same shape on purpose, so `PlayerService` can swap its source without reshaping anything downstream.

## Also extends what the ingest stores

The first version kept first/last name, position, team and the espn/yahoo ids. But the Angular source also reads **`status` (53 references), `injury_status`, `age`, `years_exp` and `number`** — shipping without them would have blanked those fields in every player view.

The field list now comes from **counted usage across the frontend**, not from guessing what seemed important.

## On the full-table scan

Deliberate, not an oversight. The endpoint returns the whole table by design, the items are small, and the table is rewritten wholesale each night. A query would need a partition key that exists only to avoid scanning something we always want in full.