### PR TITLE
#47 Add /me user API and accept Cognito tokens in the authorizer

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -90,6 +90,7 @@ jobs:
             tests/test_ai_reports_store.py \
             tests/test_season_resolver.py \
             tests/test_season_guard.py \
+            tests/test_platform_users.py \
             -v --cov=lambdas/common
 
   test-lambdas:

--- a/lambdas/api_users_me/handler.py
+++ b/lambdas/api_users_me/handler.py
@@ -1,0 +1,121 @@
+"""
+API — Current user
+==================
+GET    /me/profile         -> the caller's platform record
+PUT    /me/sleeper-link    -> link a Sleeper account
+DELETE /me/sleeper-unlink  -> unlink it
+
+One Lambda for the whole `/me` surface. These share the same record, the same
+identity read and the same response shape, and splitting them across three
+functions would mean three cold starts and three sets of IAM to keep in
+agreement for what is one small table.
+
+The paths are flat rather than the more natural `/me/sleeper` with the method
+carrying the verb: the api-gateway-service module keys one API Gateway
+resource per endpoint on `path_part`, so two methods sharing a part would
+collide at apply time.
+
+Replaces the Supabase `profiles` read that the frontend did directly against
+the database. The link step now resolves the username against Sleeper
+server-side, so an unlinkable handle is rejected at the source rather than
+being stored and failing later during roster matching.
+"""
+from typing import Any
+
+from lambdas.common import platform_users
+from lambdas.common.caller_identity import get_caller
+from lambdas.common.errors import ValidationError, handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.sleeper_helper import get_sleeper_user
+from lambdas.common.utility_helpers import parse_body, success_response
+
+HANDLER = "api_users_me"
+log = get_logger(HANDLER)
+
+
+def _shape(record: dict[str, Any]) -> dict[str, Any]:
+    """Public view of a user record.
+
+    Explicit field list rather than returning the item: the table is the
+    natural home for anything else we hang off a user, and a passthrough
+    would leak each new field to the client the moment it is written.
+
+    `hasLinkedSleeper` is computed here so the frontend guard has one boolean
+    to check instead of re-deriving the rule from field presence.
+    """
+    sleeper_user_id = record.get("sleeperUserId") or ""
+    return {
+        "userId": record.get("userId", ""),
+        "email": record.get("email", ""),
+        "sleeperUserId": sleeper_user_id,
+        "sleeperUsername": record.get("sleeperUsername", ""),
+        "sleeperAvatar": record.get("sleeperAvatar", ""),
+        "hasLinkedSleeper": bool(sleeper_user_id),
+        "createdAt": record.get("createdAt", ""),
+        "updatedAt": record.get("updatedAt", ""),
+    }
+
+
+# Final path segment -> (action, expected method). The method is checked as
+# well as the segment so a misconfigured route fails loudly here rather than
+# quietly performing the wrong action on the record.
+_ROUTES = {
+    "profile": ("get", "GET"),
+    "sleeper-link": ("link", "PUT"),
+    "sleeper-unlink": ("unlink", "DELETE"),
+}
+
+
+def _route(event: dict[str, Any]) -> str:
+    method = (event.get("httpMethod") or "GET").upper()
+    path = event.get("path") or event.get("resource") or ""
+    segment = path.rstrip("/").rsplit("/", 1)[-1]
+
+    matched = _ROUTES.get(segment)
+    if not matched or matched[1] != method:
+        raise ValidationError(f"Unsupported route: {method} {path}")
+    return matched[0]
+
+
+def _link(user_id: str, event: dict[str, Any]) -> dict[str, Any]:
+    body = parse_body(event)
+    username = str(body.get("sleeperUsername") or "").strip()
+    if not username:
+        raise ValidationError("sleeperUsername is required")
+
+    # Sleeper's /user/{id_or_username} accepts either form, so this both
+    # validates the handle and resolves it to the stable numeric id that
+    # every roster lookup keys on. Storing the username alone would break
+    # the moment someone renames.
+    # Sleeper answers an unknown handle with HTTP 200 and a null body
+    # rather than a 404, so the miss shows up here as a falsy profile,
+    # not as a raised SleeperAPIError.
+    profile = get_sleeper_user(username)
+    if not profile or not profile.get("user_id"):
+        raise ValidationError(f"No Sleeper account found for '{username}'")
+
+    return platform_users.link_sleeper(
+        user_id=user_id,
+        sleeper_user_id=str(profile["user_id"]),
+        sleeper_username=str(profile.get("username") or username),
+        avatar=profile.get("avatar"),
+    )
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    caller = get_caller(event)
+    action = _route(event)
+
+    # Every path needs the record to exist first: link and unlink are
+    # update_item calls, which would otherwise create a partial row with no
+    # email or createdAt.
+    record = platform_users.ensure_user(caller.user_id, caller.email)
+
+    if action == "link":
+        record = _link(caller.user_id, event)
+    elif action == "unlink":
+        record = platform_users.unlink_sleeper(caller.user_id)
+
+    log.info(f"users/me: {action} for {caller.user_id} via {caller.provider}")
+    return success_response({"user": _shape(record)})

--- a/lambdas/authorizer/handler.py
+++ b/lambdas/authorizer/handler.py
@@ -1,15 +1,29 @@
 """
 Lambda Authorizer
 =================
-API Gateway authorizer for Xomper. Verifies Supabase access tokens
-signed with ES256 via the project's published JWKS.
+API Gateway authorizer for Xomper. Accepts either identity provider while the
+platform migrates from Supabase to Cognito.
 
-Supabase JWTs use ES256 (ECDSA P-256) signed with a project-scoped
-key pair. Public keys are published at
-`{SUPABASE_URL}/auth/v1/.well-known/jwks.json`. PyJWKClient fetches +
-caches them at module load, so verification on each invocation is a
-local signature check.
+Supabase issues ES256 tokens signed with a project-scoped key pair, published
+at `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`.
+
+Cognito issues RS256 tokens for the shared `xomware-users` pool, published at
+`https://cognito-idp.{region}.amazonaws.com/{poolId}/.well-known/jwks.json`.
+
+Accepting both is deliberate. A single-provider authorizer forces a flag day:
+the frontend and the API have to switch in the same deploy, and any user
+holding a session from the old provider is signed out mid-migration. Verifying
+both means the frontend can move whenever it is ready, and this narrows back
+to Cognito alone once nothing issues Supabase tokens.
+
+Both clients cache their keys at module load, so verification on each
+invocation is a local signature check.
+
+Claims are returned to the caller as `principalId` and in the authorizer
+context, so downstream handlers can identify the user without re-decoding.
 """
+
+from __future__ import annotations
 
 import os
 
@@ -23,19 +37,33 @@ log = get_logger(__file__)
 
 HANDLER = 'authorizer'
 
-# Module-level so PyJWKClient's internal key cache survives across
-# Lambda warm invocations.
+# Module-level so PyJWKClient's internal key cache survives warm invocations.
 _SUPABASE_URL = (os.environ.get('SUPABASE_URL') or '').rstrip('/')
-_JWKS_URL = f"{_SUPABASE_URL}/auth/v1/.well-known/jwks.json" if _SUPABASE_URL else ''
-_jwks_client: PyJWKClient | None = (
-    PyJWKClient(_JWKS_URL, cache_keys=True) if _JWKS_URL else None
+_SUPABASE_JWKS = (
+    f"{_SUPABASE_URL}/auth/v1/.well-known/jwks.json" if _SUPABASE_URL else ''
+)
+_supabase_jwks: PyJWKClient | None = (
+    PyJWKClient(_SUPABASE_JWKS, cache_keys=True) if _SUPABASE_JWKS else None
+)
+
+_COGNITO_POOL_ID = os.environ.get('COGNITO_USER_POOL_ID') or ''
+_COGNITO_CLIENT_ID = os.environ.get('COGNITO_CLIENT_ID') or ''
+_AWS_REGION = os.environ.get('AWS_REGION') or 'us-east-1'
+_COGNITO_JWKS = (
+    f"https://cognito-idp.{_AWS_REGION}.amazonaws.com/"
+    f"{_COGNITO_POOL_ID}/.well-known/jwks.json"
+    if _COGNITO_POOL_ID
+    else ''
+)
+_cognito_jwks: PyJWKClient | None = (
+    PyJWKClient(_COGNITO_JWKS, cache_keys=True) if _COGNITO_JWKS else None
 )
 
 
-def generate_policy(effect: str, resource: str) -> dict:
+def generate_policy(effect: str, resource: str, claims: dict | None = None) -> dict:
     """Return a valid AWS IAM policy response for API Gateway."""
-    return {
-        'principalId': PRODUCT,
+    policy = {
+        'principalId': (claims or {}).get('sub') or PRODUCT,
         'policyDocument': {
             'Version': '2012-10-17',
             'Statement': [
@@ -48,32 +76,89 @@ def generate_policy(effect: str, resource: str) -> dict:
         }
     }
 
+    if claims:
+        # Context values must be strings. Handlers read these instead of
+        # decoding the token a second time.
+        groups = claims.get('cognito:groups') or []
+        policy['context'] = {
+            'sub': str(claims.get('sub') or ''),
+            'email': str(claims.get('email') or ''),
+            'provider': str(claims.get('_provider') or ''),
+            'groups': ','.join(groups) if isinstance(groups, list) else str(groups),
+        }
 
-def decode_auth_token(auth_token: str) -> dict | None:
-    """Decode + verify a Supabase JWT. Returns claims dict or None on
-    any failure (expired, bad signature, missing key, etc.)."""
-    if _jwks_client is None:
-        log.error("Authorizer: SUPABASE_URL env var missing — cannot verify tokens")
+    return policy
+
+
+def _try_supabase(token: str) -> dict | None:
+    if _supabase_jwks is None:
         return None
     try:
-        token = auth_token.replace('Bearer ', '').strip()
-        signing_key = _jwks_client.get_signing_key_from_jwt(token)
-        return jwt.decode(
+        signing_key = _supabase_jwks.get_signing_key_from_jwt(token)
+        claims = jwt.decode(
             token,
             signing_key.key,
             algorithms=['ES256'],
             audience='authenticated',
         )
+        claims['_provider'] = 'supabase'
+        return claims
     except jwt.ExpiredSignatureError:
-        log.warning("Authorizer: token expired")
+        log.warning("Authorizer: supabase token expired")
         return None
-    except jwt.InvalidTokenError as err:
-        log.warning(f"Authorizer: invalid token - {err}")
+    except Exception:
+        # Wrong issuer is the common case now that two providers are live, and
+        # it is not worth a warning on every Cognito request.
         return None
-    except Exception as err:
-        # Network failures fetching JWKS, malformed token header, etc.
-        log.warning(f"Authorizer: decode error - {err}")
+
+
+def _try_cognito(token: str) -> dict | None:
+    if _cognito_jwks is None:
         return None
+    try:
+        signing_key = _cognito_jwks.get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=['RS256'],
+            # Cognito ACCESS tokens carry no `aud`, only `client_id`; ID tokens
+            # carry `aud`. Verifying audience here would reject access tokens
+            # outright, so the client is checked below instead.
+            options={'verify_aud': False},
+            issuer=(
+                f"https://cognito-idp.{_AWS_REGION}.amazonaws.com/"
+                f"{_COGNITO_POOL_ID}"
+            ),
+        )
+    except jwt.ExpiredSignatureError:
+        log.warning("Authorizer: cognito token expired")
+        return None
+    except Exception:
+        return None
+
+    # A token from another app client on the shared pool is a valid Cognito
+    # token but not one for this app. The pool is estate-wide, so this check is
+    # what keeps xomforms or xomtracks sessions out of Xomper's API.
+    if _COGNITO_CLIENT_ID:
+        presented = claims.get('client_id') or claims.get('aud')
+        if presented != _COGNITO_CLIENT_ID:
+            log.warning("Authorizer: cognito token for a different app client")
+            return None
+
+    claims['_provider'] = 'cognito'
+    return claims
+
+
+def decode_auth_token(auth_token: str) -> dict | None:
+    """Verify against either provider. Returns claims or None."""
+    token = auth_token.replace('Bearer ', '').strip()
+    if not token:
+        return None
+
+    claims = _try_cognito(token) or _try_supabase(token)
+    if claims is None:
+        log.warning("Authorizer: token matched neither provider")
+    return claims
 
 
 def handler(event: dict, context: object) -> dict:
@@ -91,8 +176,8 @@ def handler(event: dict, context: object) -> dict:
             log.error("Authorizer: no methodArn in event")
             return generate_policy('Deny', method_arn)
 
-        user_details = decode_auth_token(auth_token)
-        if user_details:
+        claims = decode_auth_token(auth_token)
+        if claims:
             arn_parts = method_arn.split(':')
             api_gateway_arn_tmp = arn_parts[5].split('/')
             resource_arn = (
@@ -100,7 +185,8 @@ def handler(event: dict, context: object) -> dict:
                 f"{arn_parts[3]}:{arn_parts[4]}:"
                 f"{api_gateway_arn_tmp[0]}/{api_gateway_arn_tmp[1]}/*"
             )
-            return generate_policy('Allow', resource_arn)
+            log.info(f"Authorizer: Allow via {claims.get('_provider')}")
+            return generate_policy('Allow', resource_arn, claims)
 
         log.warning("Authorizer: Deny - token decode failed")
         return generate_policy('Deny', method_arn)

--- a/lambdas/common/caller_identity.py
+++ b/lambdas/common/caller_identity.py
@@ -1,0 +1,56 @@
+"""
+Caller identity
+===============
+Reads who is calling out of the API Gateway request context.
+
+The Lambda authorizer already verified the token and put the claims it cares
+about into `requestContext.authorizer`. Handlers read them from there rather
+than decoding the Authorization header a second time — the decode is the
+authorizer's job, and a handler that repeats it can disagree with the decision
+that let the request through.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from lambdas.common.errors import AuthorizationError
+
+
+@dataclass
+class Caller:
+    """The authenticated user behind a request."""
+
+    user_id: str
+    email: str = ""
+    provider: str = ""
+    groups: list[str] = field(default_factory=list)
+
+    @property
+    def is_admin(self) -> bool:
+        return "admin" in self.groups
+
+
+def get_caller(event: dict[str, Any]) -> Caller:
+    """Extract the caller, raising 401 if the context is missing.
+
+    A missing context means the request reached the handler without passing
+    the authorizer, which should be impossible on a protected route. Treat it
+    as unauthenticated rather than defaulting to an anonymous user, so a route
+    accidentally wired without an authorizer fails closed.
+    """
+    context = (event.get("requestContext") or {}).get("authorizer") or {}
+    user_id = context.get("sub") or ""
+
+    if not user_id:
+        raise AuthorizationError("No authenticated caller on this request")
+
+    raw_groups = context.get("groups") or ""
+    groups = [g for g in str(raw_groups).split(",") if g]
+
+    return Caller(
+        user_id=user_id,
+        email=context.get("email") or "",
+        provider=context.get("provider") or "",
+        groups=groups,
+    )

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -105,3 +105,7 @@ ADMIN_LOG_GROUP_ALLOWLIST = {
 WAREHOUSE_BUCKET_NAME = os.environ.get("WAREHOUSE_BUCKET", "xomper-warehouse")
 PLAYERS_TABLE_NAME = os.environ.get("PLAYERS_TABLE", "xomper-players")
 STATS_TABLE_NAME = os.environ.get("STATS_TABLE", "xomper-stats-current")
+
+# Platform identity (Phase 4.6). Cognito holds credentials; this table holds
+# what Cognito does not — which Sleeper account a user has linked.
+PLATFORM_USERS_TABLE = os.environ.get("PLATFORM_USERS_TABLE", "xomper-users")

--- a/lambdas/common/platform_users.py
+++ b/lambdas/common/platform_users.py
@@ -1,0 +1,143 @@
+"""
+Platform user store
+===================
+The `xomper-users` table: one item per Cognito user, holding what the pool
+does not.
+
+The shared `xomware-users` pool is estate-wide — the same identity signs into
+xomware.com, xomforms and Xomper. Sleeper linkage is Xomper's alone, so it
+lives here rather than as a custom pool attribute. That also keeps the record
+extensible (followed leagues, strategy presets) without touching a pool five
+other apps depend on.
+
+This replaces the Supabase `profiles` contract. There is no migration: the
+platform starts empty, and the existing `profiles` rows stay with
+clt-dynasty-league.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from lambdas.common.constants import PLATFORM_USERS_TABLE
+from lambdas.common.errors import DynamoDBError
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import get_iso_timestamp
+
+log = get_logger(__name__)
+
+
+def _table() -> Any:
+    return boto3.resource("dynamodb").Table(PLATFORM_USERS_TABLE)
+
+
+def get_user(user_id: str) -> dict[str, Any] | None:
+    """Return the stored record, or None if this user has never been seen."""
+    try:
+        response = _table().get_item(Key={"userId": user_id})
+    except ClientError as err:
+        raise DynamoDBError(f"get_user failed: {err}") from err
+    return response.get("Item")
+
+
+def ensure_user(user_id: str, email: str | None) -> dict[str, Any]:
+    """Return the user's record, creating a bare one on first sight.
+
+    Sign-up happens entirely in Cognito, so the first this table hears of a
+    user is their first authenticated request. Creating the row lazily here
+    means there is no Cognito trigger to keep in sync, and no window where a
+    signed-in user has no record.
+    """
+    existing = get_user(user_id)
+    if existing:
+        # Backfill an email that arrived later — federated sign-ups can reach
+        # us before the pool has the claim populated.
+        if email and not existing.get("email"):
+            try:
+                _table().update_item(
+                    Key={"userId": user_id},
+                    UpdateExpression="SET email = :e, updatedAt = :t",
+                    ExpressionAttributeValues={
+                        ":e": email,
+                        ":t": get_iso_timestamp(),
+                    },
+                )
+            except ClientError as err:
+                raise DynamoDBError(f"ensure_user backfill failed: {err}") from err
+            existing["email"] = email
+        return existing
+
+    now = get_iso_timestamp()
+    record = {
+        "userId": user_id,
+        "email": email or "",
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    try:
+        # Guard against two concurrent first requests racing to create the
+        # row. Losing the race is not an error — the winner wrote the same
+        # thing — so fall through to a read.
+        _table().put_item(
+            Item=record,
+            ConditionExpression="attribute_not_exists(userId)",
+        )
+    except ClientError as err:
+        if err.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return get_user(user_id) or record
+        raise DynamoDBError(f"ensure_user create failed: {err}") from err
+
+    log.info(f"platform_users: created record for {user_id}")
+    return record
+
+
+def link_sleeper(
+    user_id: str,
+    sleeper_user_id: str,
+    sleeper_username: str,
+    avatar: str | None = None,
+) -> dict[str, Any]:
+    """Attach a verified Sleeper account to this user.
+
+    The caller is responsible for having resolved the username against
+    Sleeper first — this writes what it is given.
+    """
+    try:
+        response = _table().update_item(
+            Key={"userId": user_id},
+            UpdateExpression=(
+                "SET sleeperUserId = :sid, sleeperUsername = :name, "
+                "sleeperAvatar = :av, updatedAt = :t"
+            ),
+            ExpressionAttributeValues={
+                ":sid": sleeper_user_id,
+                ":name": sleeper_username,
+                ":av": avatar or "",
+                ":t": get_iso_timestamp(),
+            },
+            ReturnValues="ALL_NEW",
+        )
+    except ClientError as err:
+        raise DynamoDBError(f"link_sleeper failed: {err}") from err
+
+    log.info(f"platform_users: linked {user_id} -> sleeper {sleeper_user_id}")
+    return response.get("Attributes", {})
+
+
+def unlink_sleeper(user_id: str) -> dict[str, Any]:
+    """Detach the Sleeper account, leaving the rest of the record intact."""
+    try:
+        response = _table().update_item(
+            Key={"userId": user_id},
+            UpdateExpression=(
+                "REMOVE sleeperUserId, sleeperUsername, sleeperAvatar "
+                "SET updatedAt = :t"
+            ),
+            ExpressionAttributeValues={":t": get_iso_timestamp()},
+            ReturnValues="ALL_NEW",
+        )
+    except ClientError as err:
+        raise DynamoDBError(f"unlink_sleeper failed: {err}") from err
+    return response.get("Attributes", {})

--- a/tests/test_api_users_me.py
+++ b/tests/test_api_users_me.py
@@ -1,0 +1,180 @@
+"""
+Tests for `lambdas.api_users_me.handler`.
+
+This endpoint replaces the direct Supabase `profiles` read the frontend used
+to do. The behaviour that matters is that identity comes from the authorizer
+context and nowhere else, and that a Sleeper handle is verified against
+Sleeper before it is stored.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from lambdas.common.constants import PLATFORM_USERS_TABLE
+
+SLEEPER_PROFILE = {
+    "user_id": "594625531702460416",
+    "username": "dgiordano",
+    "avatar": "abc123",
+}
+
+
+@pytest.fixture
+def users_table():
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName=PLATFORM_USERS_TABLE,
+            KeySchema=[{"AttributeName": "userId", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "userId", "AttributeType": "S"}
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield dynamodb.Table(PLATFORM_USERS_TABLE)
+
+
+@pytest.fixture
+def mod(users_table):
+    from lambdas.common import platform_users
+
+    importlib.reload(platform_users)
+    from lambdas.api_users_me import handler as handler_mod
+
+    return importlib.reload(handler_mod)
+
+
+def event(method="GET", path="/me/profile", body=None, sub="cog-1", email="d@x.com"):
+    return {
+        "httpMethod": method,
+        "path": path,
+        "body": json.dumps(body) if body is not None else None,
+        "requestContext": {
+            "authorizer": {"sub": sub, "email": email, "provider": "cognito"}
+        },
+    }
+
+
+def body_of(response):
+    return json.loads(response["body"])
+
+
+def test_get_creates_the_record_on_first_call(mod):
+    response = mod.handler(event(), None)
+
+    assert response["statusCode"] == 200
+    user = body_of(response)["user"]
+    assert user["userId"] == "cog-1"
+    assert user["email"] == "d@x.com"
+    assert user["hasLinkedSleeper"] is False
+
+
+def test_identity_comes_from_the_authorizer_not_the_body(mod):
+    # A caller must not be able to read or mutate someone else's record by
+    # naming them in the payload.
+    response = mod.handler(
+        event(body={"userId": "someone-else"}, sub="cog-1"), None
+    )
+
+    assert body_of(response)["user"]["userId"] == "cog-1"
+
+
+def test_missing_authorizer_context_is_rejected(mod):
+    bare = event()
+    bare["requestContext"] = {}
+
+    response = mod.handler(bare, None)
+
+    # Fail closed: a route accidentally wired without an authorizer must not
+    # fall through to an anonymous user.
+    assert response["statusCode"] == 401
+
+
+def test_link_resolves_the_username_against_sleeper(mod, monkeypatch):
+    monkeypatch.setattr(mod, "get_sleeper_user", lambda _: SLEEPER_PROFILE)
+
+    response = mod.handler(
+        event(
+            method="PUT",
+            path="/me/sleeper-link",
+            body={"sleeperUsername": "dgiordano"},
+        ),
+        None,
+    )
+
+    user = body_of(response)["user"]
+    assert user["sleeperUserId"] == "594625531702460416"
+    assert user["sleeperUsername"] == "dgiordano"
+    assert user["hasLinkedSleeper"] is True
+
+
+def test_link_rejects_an_unknown_handle(mod, monkeypatch):
+    # Sleeper answers an unknown handle with HTTP 200 and a null body.
+    monkeypatch.setattr(mod, "get_sleeper_user", lambda _: None)
+
+    response = mod.handler(
+        event(
+            method="PUT",
+            path="/me/sleeper-link",
+            body={"sleeperUsername": "not-a-real-handle"},
+        ),
+        None,
+    )
+
+    assert response["statusCode"] == 400
+    assert mod.platform_users.get_user("cog-1").get("sleeperUserId") is None
+
+
+def test_link_requires_a_username(mod):
+    response = mod.handler(
+        event(method="PUT", path="/me/sleeper-link", body={}), None
+    )
+
+    assert response["statusCode"] == 400
+
+
+def test_unlink_clears_the_link(mod, monkeypatch):
+    monkeypatch.setattr(mod, "get_sleeper_user", lambda _: SLEEPER_PROFILE)
+    mod.handler(
+        event(
+            method="PUT",
+            path="/me/sleeper-link",
+            body={"sleeperUsername": "dgiordano"},
+        ),
+        None,
+    )
+
+    response = mod.handler(
+        event(method="DELETE", path="/me/sleeper-unlink"), None
+    )
+
+    assert body_of(response)["user"]["hasLinkedSleeper"] is False
+
+
+def test_response_does_not_leak_unlisted_fields(mod, users_table):
+    mod.handler(event(), None)
+    users_table.update_item(
+        Key={"userId": "cog-1"},
+        UpdateExpression="SET espnCookie = :c",
+        ExpressionAttributeValues={":c": "secret"},
+    )
+
+    user = body_of(mod.handler(event(), None))["user"]
+
+    # The shape is an explicit allowlist so future columns are opt-in.
+    assert "espnCookie" not in user
+
+
+def test_a_method_mismatch_is_rejected(mod):
+    # The path segment alone does not decide the action — a route wired with
+    # the wrong method must fail rather than silently unlink on a PUT.
+    response = mod.handler(
+        event(method="PUT", path="/me/sleeper-unlink", body={}), None
+    )
+
+    assert response["statusCode"] == 400

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -1,0 +1,205 @@
+"""
+Tests for `lambdas.authorizer.handler`.
+
+The authorizer accepts Supabase (ES256) and Cognito (RS256) while the platform
+migrates between them. Tokens here are really signed and really verified — the
+JWKS *fetch* is stubbed, the signature check is not, so a change that weakens
+verification fails these rather than passing on a mock.
+
+The case that matters most is the last one: the shared `xomware-users` pool
+issues tokens for every Xomware app, so a valid Cognito token is not by itself
+a token for Xomper.
+"""
+from __future__ import annotations
+
+import importlib
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+POOL_ID = "us-east-1_ZrN8NaaIv"
+CLIENT_ID = "38e5sjavoa76ghbl5hpjsapc49"
+REGION = "us-east-1"
+ISSUER = f"https://cognito-idp.{REGION}.amazonaws.com/{POOL_ID}"
+SUPABASE_URL = "https://proj.supabase.co"
+METHOD_ARN = (
+    "arn:aws:execute-api:us-east-1:123456789012:abc123/dev/GET/users/me"
+)
+
+RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+EC_KEY = ec.generate_private_key(ec.SECP256R1())
+OTHER_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture
+def authorizer(monkeypatch):
+    """Load the authorizer with both providers configured.
+
+    Each provider's PyJWKClient is replaced with a stub that returns a fixed
+    key, standing in for the JWKS endpoint. Everything downstream of the key
+    lookup — signature, expiry, issuer, client — runs for real.
+    """
+    monkeypatch.setenv("SUPABASE_URL", SUPABASE_URL)
+    monkeypatch.setenv("COGNITO_USER_POOL_ID", POOL_ID)
+    monkeypatch.setenv("COGNITO_CLIENT_ID", CLIENT_ID)
+    monkeypatch.setenv("AWS_REGION", REGION)
+
+    from lambdas.authorizer import handler as mod
+
+    mod = importlib.reload(mod)
+
+    class Stub:
+        def __init__(self, key):
+            self.key = key
+
+        def get_signing_key_from_jwt(self, _token):
+            return self
+
+    monkeypatch.setattr(mod, "_cognito_jwks", Stub(RSA_KEY.public_key()))
+    monkeypatch.setattr(mod, "_supabase_jwks", Stub(EC_KEY.public_key()))
+    return mod
+
+
+def cognito_token(key=RSA_KEY, **overrides):
+    claims = {
+        "sub": "cog-user-1",
+        "email": "d@x.com",
+        "iss": ISSUER,
+        "aud": CLIENT_ID,
+        "token_use": "id",
+        "exp": 4102444800,  # 2100-01-01
+        **overrides,
+    }
+    return jwt.encode(claims, key, algorithm="RS256")
+
+
+def supabase_token(**overrides):
+    claims = {
+        "sub": "sb-user-1",
+        "email": "d@x.com",
+        "aud": "authenticated",
+        "exp": 4102444800,
+        **overrides,
+    }
+    return jwt.encode(claims, EC_KEY, algorithm="ES256")
+
+
+def effect(policy):
+    return policy["policyDocument"]["Statement"][0]["Effect"]
+
+
+def test_allows_a_cognito_token(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token()}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Allow"
+    assert policy["context"]["provider"] == "cognito"
+    assert policy["context"]["sub"] == "cog-user-1"
+
+
+def test_allows_a_supabase_token(authorizer):
+    # Both providers stay live through the migration so a user holding a
+    # Supabase session is not signed out mid-deploy.
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {supabase_token()}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Allow"
+    assert policy["context"]["provider"] == "supabase"
+
+
+def test_passes_cognito_groups_through_for_admin_checks(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token(**{'cognito:groups': ['admin']})}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert policy["context"]["groups"] == "admin"
+
+
+def test_denies_a_token_signed_by_the_wrong_key(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token(key=OTHER_RSA_KEY)}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Deny"
+
+
+def test_denies_an_expired_token(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token(exp=1000000000)}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Deny"
+
+
+def test_denies_a_wrong_issuer(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token(iss='https://evil.example')}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Deny"
+
+
+def test_denies_a_missing_token(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": "", "methodArn": METHOD_ARN}, None
+    )
+
+    assert effect(policy) == "Deny"
+
+
+def test_denies_a_token_for_another_app_on_the_shared_pool(authorizer):
+    # xomforms and xomtracks sign into the same pool. Their tokens are
+    # correctly signed by the same keys and carry the same issuer — the app
+    # client is the only thing separating them.
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token(aud='82sn0drkf2fvfjn94nmoc857p')}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Deny"
+
+
+def test_accepts_an_access_token_which_carries_client_id_not_aud(authorizer):
+    token = cognito_token(token_use="access", client_id=CLIENT_ID)
+    stripped = jwt.encode(
+        {k: v for k, v in jwt.decode(token, options={"verify_signature": False}).items()
+         if k != "aud"},
+        RSA_KEY,
+        algorithm="RS256",
+    )
+
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {stripped}", "methodArn": METHOD_ARN},
+        None,
+    )
+
+    assert effect(policy) == "Allow"
+
+
+def test_allow_is_scoped_to_the_api_stage_not_one_method(authorizer):
+    policy = authorizer.handler(
+        {"authorizationToken": f"Bearer {cognito_token()}",
+         "methodArn": METHOD_ARN},
+        None,
+    )
+
+    resource = policy["policyDocument"]["Statement"][0]["Resource"]
+    # Wildcarding the stage is what makes the decision cacheable across
+    # routes; without it every endpoint pays a fresh authorizer invocation.
+    assert resource.endswith("abc123/dev/*")

--- a/tests/test_platform_users.py
+++ b/tests/test_platform_users.py
@@ -1,0 +1,131 @@
+"""
+Tests for `lambdas.common.platform_users`.
+
+Uses `moto` against the `xomper-users` schema from
+xomper-infrastructure/terraform/platform_users.tf:
+- PK `userId` (S)
+- GSI `sleeperUserId-index` on `sleeperUserId` (S)
+
+The behaviour worth pinning here is lazy creation. Sign-up happens entirely
+in Cognito, so this table first hears of a user on their first authenticated
+request — and two requests can land at once.
+"""
+from __future__ import annotations
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from lambdas.common.constants import PLATFORM_USERS_TABLE
+
+
+@pytest.fixture
+def users_table():
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName=PLATFORM_USERS_TABLE,
+            KeySchema=[{"AttributeName": "userId", "KeyType": "HASH"}],
+            AttributeDefinitions=[
+                {"AttributeName": "userId", "AttributeType": "S"},
+                {"AttributeName": "sleeperUserId", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "sleeperUserId-index",
+                    "KeySchema": [
+                        {"AttributeName": "sleeperUserId", "KeyType": "HASH"}
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield dynamodb.Table(PLATFORM_USERS_TABLE)
+
+
+@pytest.fixture
+def store():
+    import importlib
+
+    from lambdas.common import platform_users
+
+    return importlib.reload(platform_users)
+
+
+def test_get_user_returns_none_when_absent(users_table, store):
+    assert store.get_user("nobody") is None
+
+
+def test_ensure_user_creates_on_first_sight(users_table, store):
+    record = store.ensure_user("cog-1", "dom@example.com")
+
+    assert record["userId"] == "cog-1"
+    assert record["email"] == "dom@example.com"
+    assert record["createdAt"]
+    assert store.get_user("cog-1") is not None
+
+
+def test_ensure_user_is_idempotent(users_table, store):
+    first = store.ensure_user("cog-1", "dom@example.com")
+    second = store.ensure_user("cog-1", "dom@example.com")
+
+    # The second call must not reset createdAt — that timestamp is the only
+    # record of when the account started here.
+    assert second["createdAt"] == first["createdAt"]
+
+
+def test_ensure_user_backfills_a_late_email(users_table, store):
+    store.ensure_user("cog-1", None)
+    record = store.ensure_user("cog-1", "later@example.com")
+
+    assert record["email"] == "later@example.com"
+
+
+def test_ensure_user_does_not_clobber_a_link(users_table, store):
+    store.ensure_user("cog-1", "dom@example.com")
+    store.link_sleeper("cog-1", "594625531702460416", "dgiordano")
+
+    record = store.ensure_user("cog-1", "dom@example.com")
+
+    # A second sign-in must not wipe the Sleeper linkage, which would bounce
+    # the user back to /link-sleeper on every visit.
+    assert record["sleeperUserId"] == "594625531702460416"
+
+
+def test_link_sleeper_stores_id_username_and_avatar(users_table, store):
+    store.ensure_user("cog-1", "dom@example.com")
+    record = store.link_sleeper(
+        "cog-1", "594625531702460416", "dgiordano", avatar="abc123"
+    )
+
+    assert record["sleeperUserId"] == "594625531702460416"
+    assert record["sleeperUsername"] == "dgiordano"
+    assert record["sleeperAvatar"] == "abc123"
+
+
+def test_link_sleeper_is_reachable_by_the_gsi(users_table, store):
+    store.ensure_user("cog-1", "dom@example.com")
+    store.link_sleeper("cog-1", "594625531702460416", "dgiordano")
+
+    found = users_table.query(
+        IndexName="sleeperUserId-index",
+        KeyConditionExpression=boto3.dynamodb.conditions.Key(
+            "sleeperUserId"
+        ).eq("594625531702460416"),
+    )
+
+    # This index is how a shared league resolves which other managers on a
+    # roster have accounts here.
+    assert found["Count"] == 1
+    assert found["Items"][0]["userId"] == "cog-1"
+
+
+def test_unlink_removes_the_link_but_keeps_the_user(users_table, store):
+    store.ensure_user("cog-1", "dom@example.com")
+    store.link_sleeper("cog-1", "594625531702460416", "dgiordano")
+
+    record = store.unlink_sleeper("cog-1")
+
+    assert "sleeperUserId" not in record
+    assert record["email"] == "dom@example.com"


### PR DESCRIPTION
Backend half of moving Xomper off Supabase auth. Pairs with Xomware/xomper-infrastructure#133, which must merge first.

Nothing about the live auth flow changes when this lands — the Supabase path keeps working exactly as it does today.

Part of #47.

## Authorizer takes either provider

`lambdas/authorizer` now verifies Cognito RS256 as well as Supabase ES256.

A single-provider authorizer forces a flag day: frontend and API cut over in the same deploy, and anyone holding a session from the old provider is signed out mid-migration. Accepting both means the frontend moves on its own schedule, and this narrows back to Cognito alone once nothing issues Supabase tokens.

Two things worth a look:

- **The shared pool is estate-wide.** xomforms, xomtracks and xomware.com all sign into `xomware-users`. Their tokens carry the same issuer and are signed by the same keys — the **app client id is the only thing separating them**, so that check is what keeps a xomforms session out of Xomper's API. Covered by `test_denies_a_token_for_another_app_on_the_shared_pool`.
- **`verify_aud` is off, deliberately.** Cognito access tokens carry `client_id` and no `aud`; ID tokens carry `aud`. Verifying audience the normal way would reject access tokens outright, so the client is checked explicitly against both claims instead.

Verified claims now reach handlers through the authorizer context (`sub`, `email`, `provider`, `groups`) rather than being decoded a second time — a handler that re-decodes can disagree with the decision that let the request through. `cognito:groups` comes through too, which is what the rebuilt admin gate will key on.

## /me endpoints

`lambdas/api_users_me` serves all three routes:

| Route | Method | Does |
|---|---|---|
| `/me/profile` | GET | the caller's record, created on first sight |
| `/me/sleeper-link` | PUT | resolve a Sleeper handle and attach it |
| `/me/sleeper-unlink` | DELETE | detach it |

This replaces the frontend reading the Supabase `profiles` table directly. Two changes in behaviour:

- **Linking verifies first.** The handle is resolved against Sleeper server-side, so a bad username returns 400 instead of being stored and failing later during roster matching. Note Sleeper answers an unknown handle with HTTP 200 and a `null` body rather than a 404 — the miss shows up as a falsy profile, not a raised error.
- **Records are created lazily.** Sign-up happens entirely in Cognito, so this table first hears of a user on their first authenticated request. No Cognito trigger to keep in sync, and no window where a signed-in user has no record. The create is guarded by `attribute_not_exists` so two concurrent first requests don't race.

`ensure_user` runs on every path, including link and unlink — those are `update_item` calls that would otherwise create a partial row with no `email` or `createdAt`.

The response shape is an explicit allowlist, not a passthrough of the item. This table is the natural home for whatever else we hang off a user, and a passthrough leaks each new field to the client the moment it's written. `hasLinkedSleeper` is computed server-side so the frontend guard checks one boolean instead of re-deriving the rule.

## Tests

**651 pass on Python 3.13** (matching CI).

The authorizer tests **sign and verify real tokens** — only the JWKS *fetch* is stubbed, so a change that weakens verification fails them rather than passing against a mock. Wrong key, expired, wrong issuer, and wrong app client all assert Deny.

Also pinned: identity comes from the authorizer context and not the request body; a missing authorizer context fails closed at 401 rather than falling through to an anonymous user; `ensure_user` doesn't clobber an existing Sleeper link on re-login (which would bounce the user to `/link-sleeper` on every visit).

`tests/test_platform_users.py` is added to the common-module test list in the deploy workflow.

## Heads up

Local runs on Python 3.9 show unrelated collection errors from `X | None` annotations in existing modules — CI is on 3.13 where the full suite is green. Not introduced here, and not fixed here either.