### PR TITLE
Add a deploy_all switch to the backend deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
   workflow_dispatch:
+    inputs:
+      deploy_all:
+        description: 'Deploy every lambda, not just the ones changed in the last commit'
+        required: false
+        type: boolean
+        default: false
 
 env:
   AWS_REGION: "us-east-1"
@@ -42,6 +48,17 @@ jobs:
 
           # Find changed lambda folders (excluding common) and format as JSON array
           CHANGED_LAMBDAS=$(echo "$CHANGED_FILES" | grep "^lambdas/" | grep -v "^lambdas/common/" | cut -d'/' -f2 | sort -u | grep -v '^$' || true)
+
+          # A lambda that Terraform created but nobody has edited since is
+          # never "changed", so its code is never pushed and it keeps serving
+          # the stub -- answering every request with
+          # `Runtime.ImportModuleError: No module named 'handler'`. That went
+          # unnoticed for as long as the authorizer denied every request
+          # before it reached a handler. This switch is the way back.
+          if [ "${{ inputs.deploy_all }}" = "true" ]; then
+            echo "deploy_all requested — deploying every lambda"
+            CHANGED_LAMBDAS=$(ls -d lambdas/*/ | grep -v "lambdas/common" | xargs -n1 basename)
+          fi
 
           if [ -n "$CHANGED_LAMBDAS" ]; then
             # Convert to JSON array


### PR DESCRIPTION
## The problem

The deploy computes its matrix from `git diff HEAD~1 HEAD`. A Lambda that Terraform created but nobody has edited since is never "changed", so its code is never pushed — it keeps serving `templates/lambda_stub.zip` and answers every request with:

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'handler': No module named 'handler'
```

**36 functions are in that state right now** (526 bytes each). Most are unrouted CLT-era CRUD and harmless, but these are wired to live routes:

- `xomper-api-announcements` → `/announcements/list` — **the frontend calls this on every home load**
- `xomper-api-admin-announcements-create`, `admin-leagues-list`, `admin-leagues-update`, `admin-logs-query`, `admin-users-update` → `/admin/*`
- `xomper-api-device-register` / `-unregister` → `/device/*` (iOS)

This has been true for a long time and was invisible: the authorizer denied every request before it reached a handler, so a 500 always presented as a 403. Fixing auth is what surfaced it — I hit the announcements 500 while verifying the Cognito work in production.

## The fix

`workflow_dispatch` gains a `deploy_all` boolean. When true, the matrix becomes every folder under `lambdas/` instead of the changed ones. No behaviour change on push.

The deploy step already skips functions that don't exist in AWS, so a full run is safe.

## After merging

Run the workflow with `deploy_all: true` to fill the 36 stubs. I'll do that and confirm `/announcements/list` returns 200.