### PR TITLE
Narrow the authorizer to Cognito only

### DIFF
--- a/lambdas/authorizer/handler.py
+++ b/lambdas/authorizer/handler.py
@@ -1,26 +1,25 @@
 """
 Lambda Authorizer
 =================
-API Gateway authorizer for Xomper. Accepts either identity provider while the
-platform migrates from Supabase to Cognito.
-
-Supabase issues ES256 tokens signed with a project-scoped key pair, published
-at `{SUPABASE_URL}/auth/v1/.well-known/jwks.json`.
-
-Cognito issues RS256 tokens for the shared `xomware-users` pool, published at
+API Gateway authorizer for Xomper. Verifies Cognito RS256 tokens issued by
+the shared `xomware-users` pool, published at
 `https://cognito-idp.{region}.amazonaws.com/{poolId}/.well-known/jwks.json`.
 
-Accepting both is deliberate. A single-provider authorizer forces a flag day:
-the frontend and the API have to switch in the same deploy, and any user
-holding a session from the old provider is signed out mid-migration. Verifying
-both means the frontend can move whenever it is ready, and this narrows back
-to Cognito alone once nothing issues Supabase tokens.
+The pool is estate-wide: xomware.com, xomforms and xomtracks all sign into
+it, so their tokens carry the same issuer and are signed by the same keys.
+**The app client id is the only thing scoping a token to Xomper**, which is
+what the client check below is for.
 
-Both clients cache their keys at module load, so verification on each
+This accepted Supabase ES256 tokens alongside Cognito during the migration,
+so the frontend could move without a flag day. The frontend has moved and no
+longer ships a Supabase client at all, so that path is gone. Note this means
+any caller still presenting a Supabase token now gets a 403.
+
+The JWKS client caches its keys at module load, so verification on each
 invocation is a local signature check.
 
-Claims are returned to the caller as `principalId` and in the authorizer
-context, so downstream handlers can identify the user without re-decoding.
+Claims are returned as `principalId` and in the authorizer context, so
+downstream handlers can identify the user without re-decoding.
 """
 
 from __future__ import annotations
@@ -38,14 +37,6 @@ log = get_logger(__file__)
 HANDLER = 'authorizer'
 
 # Module-level so PyJWKClient's internal key cache survives warm invocations.
-_SUPABASE_URL = (os.environ.get('SUPABASE_URL') or '').rstrip('/')
-_SUPABASE_JWKS = (
-    f"{_SUPABASE_URL}/auth/v1/.well-known/jwks.json" if _SUPABASE_URL else ''
-)
-_supabase_jwks: PyJWKClient | None = (
-    PyJWKClient(_SUPABASE_JWKS, cache_keys=True) if _SUPABASE_JWKS else None
-)
-
 _COGNITO_POOL_ID = os.environ.get('COGNITO_USER_POOL_ID') or ''
 _COGNITO_CLIENT_ID = os.environ.get('COGNITO_CLIENT_ID') or ''
 _AWS_REGION = os.environ.get('AWS_REGION') or 'us-east-1'
@@ -90,28 +81,6 @@ def generate_policy(effect: str, resource: str, claims: dict | None = None) -> d
     return policy
 
 
-def _try_supabase(token: str) -> dict | None:
-    if _supabase_jwks is None:
-        return None
-    try:
-        signing_key = _supabase_jwks.get_signing_key_from_jwt(token)
-        claims = jwt.decode(
-            token,
-            signing_key.key,
-            algorithms=['ES256'],
-            audience='authenticated',
-        )
-        claims['_provider'] = 'supabase'
-        return claims
-    except jwt.ExpiredSignatureError:
-        log.warning("Authorizer: supabase token expired")
-        return None
-    except Exception:
-        # Wrong issuer is the common case now that two providers are live, and
-        # it is not worth a warning on every Cognito request.
-        return None
-
-
 def _try_cognito(token: str) -> dict | None:
     if _cognito_jwks is None:
         return None
@@ -150,14 +119,14 @@ def _try_cognito(token: str) -> dict | None:
 
 
 def decode_auth_token(auth_token: str) -> dict | None:
-    """Verify against either provider. Returns claims or None."""
+    """Verify a Cognito token. Returns claims or None."""
     token = auth_token.replace('Bearer ', '').strip()
     if not token:
         return None
 
-    claims = _try_cognito(token) or _try_supabase(token)
+    claims = _try_cognito(token)
     if claims is None:
-        log.warning("Authorizer: token matched neither provider")
+        log.warning("Authorizer: token failed Cognito verification")
     return claims
 
 

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -102,7 +102,7 @@ def test_allows_a_cognito_token(authorizer):
 def test_denies_a_supabase_token(authorizer):
     # The dual-provider window is closed. A Supabase token is now just a
     # token signed by a key this pool does not publish. xomper-ios still
-    # sends one (Xomware/xomper-ios#1) and gets a 403 until it migrates.
+    # sends one (Xomware/xomper-ios#166) and gets a 403 until it migrates.
     policy = authorizer.handler(
         {"authorizationToken": f"Bearer {supabase_token()}",
          "methodArn": METHOD_ARN},

--- a/tests/test_authorizer.py
+++ b/tests/test_authorizer.py
@@ -1,10 +1,10 @@
 """
 Tests for `lambdas.authorizer.handler`.
 
-The authorizer accepts Supabase (ES256) and Cognito (RS256) while the platform
-migrates between them. Tokens here are really signed and really verified — the
-JWKS *fetch* is stubbed, the signature check is not, so a change that weakens
-verification fails these rather than passing on a mock.
+The authorizer verifies Cognito RS256 tokens. Tokens here are really signed
+and really verified — the JWKS *fetch* is stubbed, the signature check is not,
+so a change that weakens verification fails these rather than passing on a
+mock.
 
 The case that matters most is the last one: the shared `xomware-users` pool
 issues tokens for every Xomware app, so a valid Cognito token is not by itself
@@ -34,13 +34,12 @@ OTHER_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
 @pytest.fixture
 def authorizer(monkeypatch):
-    """Load the authorizer with both providers configured.
+    """Load the authorizer with Cognito configured.
 
-    Each provider's PyJWKClient is replaced with a stub that returns a fixed
-    key, standing in for the JWKS endpoint. Everything downstream of the key
-    lookup — signature, expiry, issuer, client — runs for real.
+    The PyJWKClient is replaced with a stub that returns a fixed key, standing
+    in for the JWKS endpoint. Everything downstream of the key lookup —
+    signature, expiry, issuer, client — runs for real.
     """
-    monkeypatch.setenv("SUPABASE_URL", SUPABASE_URL)
     monkeypatch.setenv("COGNITO_USER_POOL_ID", POOL_ID)
     monkeypatch.setenv("COGNITO_CLIENT_ID", CLIENT_ID)
     monkeypatch.setenv("AWS_REGION", REGION)
@@ -57,7 +56,6 @@ def authorizer(monkeypatch):
             return self
 
     monkeypatch.setattr(mod, "_cognito_jwks", Stub(RSA_KEY.public_key()))
-    monkeypatch.setattr(mod, "_supabase_jwks", Stub(EC_KEY.public_key()))
     return mod
 
 
@@ -101,17 +99,17 @@ def test_allows_a_cognito_token(authorizer):
     assert policy["context"]["sub"] == "cog-user-1"
 
 
-def test_allows_a_supabase_token(authorizer):
-    # Both providers stay live through the migration so a user holding a
-    # Supabase session is not signed out mid-deploy.
+def test_denies_a_supabase_token(authorizer):
+    # The dual-provider window is closed. A Supabase token is now just a
+    # token signed by a key this pool does not publish. xomper-ios still
+    # sends one (Xomware/xomper-ios#1) and gets a 403 until it migrates.
     policy = authorizer.handler(
         {"authorizationToken": f"Bearer {supabase_token()}",
          "methodArn": METHOD_ARN},
         None,
     )
 
-    assert effect(policy) == "Allow"
-    assert policy["context"]["provider"] == "supabase"
+    assert effect(policy) == "Deny"
 
 
 def test_passes_cognito_groups_through_for_admin_checks(authorizer):


### PR DESCRIPTION
Closes the dual-provider window opened in #100.

## Why now

- The frontend no longer ships a Supabase client at all (Xomware/xomper-frontend#136 removed the last one).
- The authorizer has recorded **zero** `Allow via supabase` decisions since Cognito went live.
- Total authorizer traffic is ~21 invocations in 30 days — essentially just verification runs.

Removes the Supabase `PyJWKClient` and the ES256 path. The test that asserted a Supabase token is *allowed* now asserts it is **denied** — that's the behaviour worth pinning, and it fails loudly if the path ever comes back.

## One real consequence

**`xomper-ios` still sends a Supabase access token** and will get 403 until it migrates:

```swift
// XomperAPIClient.swift:757
guard let session = try? await supabase.auth.session else { return }
request.setValue("Bearer \(session.accessToken)", forHTTPHeaderField: "Authorization")
```

I said "nothing issues Supabase tokens" when proposing this — that was wrong, and iOS is the exception. It isn't in active use (the traffic numbers above are the evidence), and it needs the Cognito migration regardless, so this is a scheduling question rather than a regression. Tracked in Xomware/xomper-ios#1.

## What does NOT change

`SUPABASE_URL` stays in the shared lambda env — **29 lambdas** still read Supabase tables server-side via `supabase_helper` (announcements, admin tables, audit, email archive, cron settings). Only the authorizer stops using it, so there's no Terraform change here.

## Verification

`651 tests pass`. The authorizer tests still sign and verify real tokens — only the JWKS *fetch* is stubbed — so wrong-key, expired, wrong-issuer and wrong-app-client all still assert Deny against genuine signature checks.

I'll confirm a live Cognito token still returns 200 and the routes still 403 unauthenticated after deploy.