### PR TITLE
Add followed leagues and the /me/leagues API

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -108,6 +108,7 @@ jobs:
             tests/test_season_resolver.py \
             tests/test_season_guard.py \
             tests/test_platform_users.py \
+            tests/test_platform_follows.py \
             -v --cov=lambdas/common
 
   test-lambdas:

--- a/lambdas/api_users_leagues/handler.py
+++ b/lambdas/api_users_leagues/handler.py
@@ -1,0 +1,134 @@
+"""
+API — The caller's leagues
+==========================
+GET    /me/leagues   -> every league the caller is in, with follow state
+PUT    /me/follow    -> follow one league
+DELETE /me/unfollow  -> unfollow one league
+
+This is what makes Xomper a platform rather than a single-league app. The
+frontend used to read one hardcoded league id from its environment, so every
+user saw the same league regardless of which ones they were actually in.
+
+The league list comes from Sleeper live rather than from storage: membership
+changes without telling us, and a stale list is worse than a slow one. What
+*is* stored is the follow set, because Sleeper has no concept of it.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from lambdas.common import platform_follows, platform_users
+from lambdas.common.caller_identity import get_caller
+from lambdas.common.errors import ValidationError, handle_errors
+from lambdas.common.logger import get_logger
+from lambdas.common.sleeper_helper import get_nfl_state, get_user_leagues
+from lambdas.common.utility_helpers import parse_body, success_response
+
+HANDLER = "api_users_leagues"
+log = get_logger(HANDLER)
+
+# Flat paths: api-gateway-service keys one API Gateway resource per endpoint
+# on `path_part`, so two methods on one part collide at apply time.
+def _current_season() -> str:
+    """The season Sleeper considers current.
+
+    Not the calendar year: Sleeper rolls the NFL season over in spring, so
+    deriving it from the clock serves the wrong year for months.
+    """
+    state = get_nfl_state() or {}
+    return str(state.get("season") or "")
+
+
+_ROUTES = {
+    "leagues": ("list", "GET"),
+    "follow": ("follow", "PUT"),
+    "unfollow": ("unfollow", "DELETE"),
+}
+
+
+def _route(event: dict[str, Any]) -> str:
+    method = (event.get("httpMethod") or "GET").upper()
+    path = event.get("path") or event.get("resource") or ""
+    segment = path.rstrip("/").rsplit("/", 1)[-1]
+
+    matched = _ROUTES.get(segment)
+    if not matched or matched[1] != method:
+        raise ValidationError(f"Unsupported route: {method} {path}")
+    return matched[0]
+
+
+def _shape(league: dict[str, Any], followed: set[str]) -> dict[str, Any]:
+    """Public view of a Sleeper league.
+
+    An explicit field list, not a passthrough: Sleeper's league object is
+    large and mostly irrelevant here, and the frontend re-fetches the full
+    thing for whichever league it actually opens.
+
+    `isDynasty` is derived from `settings.type` (2 = dynasty) because the
+    value provider routes on it — dynasty leagues price off FantasyCalc,
+    redraft off projections.
+    """
+    settings = league.get("settings") or {}
+    league_id = str(league.get("league_id") or "")
+    return {
+        "leagueId": league_id,
+        "name": league.get("name") or "",
+        "season": str(league.get("season") or ""),
+        "status": league.get("status") or "",
+        "totalRosters": league.get("total_rosters") or 0,
+        "avatar": league.get("avatar") or "",
+        "isDynasty": settings.get("type") == 2,
+        "isFollowed": league_id in followed,
+    }
+
+
+def _league_id_from(event: dict[str, Any]) -> str:
+    league_id = str(parse_body(event).get("leagueId") or "").strip()
+    if not league_id:
+        raise ValidationError("leagueId is required")
+    return league_id
+
+
+@handle_errors(HANDLER)
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    caller = get_caller(event)
+    action = _route(event)
+
+    if action == "follow":
+        body = parse_body(event)
+        platform_follows.follow(
+            caller.user_id,
+            _league_id_from(event),
+            name=str(body.get("name") or ""),
+            season=str(body.get("season") or ""),
+        )
+    elif action == "unfollow":
+        platform_follows.unfollow(caller.user_id, _league_id_from(event))
+
+    profile = platform_users.get_user(caller.user_id) or {}
+    sleeper_user_id = str(profile.get("sleeperUserId") or "")
+
+    if not sleeper_user_id:
+        # No linked Sleeper account means no leagues to list. An empty list
+        # rather than an error: the frontend guard already routes unlinked
+        # users to the link page, and this endpoint should not be a second
+        # place that decides what "not linked yet" means.
+        return success_response({"season": _current_season(), "count": 0, "leagues": []})
+
+    season = _current_season()
+    followed = platform_follows.followed_league_ids(caller.user_id)
+    leagues = [_shape(l, followed) for l in get_user_leagues(sleeper_user_id, season)]
+
+    # Followed first, then in-season before pre-draft, then by name — the
+    # order the frontend renders a league switcher in.
+    status_rank = {"in_season": 0, "drafting": 1, "post_season": 2, "pre_draft": 3}
+    leagues.sort(
+        key=lambda l: (
+            not l["isFollowed"],
+            status_rank.get(l["status"], 9),
+            l["name"].lower(),
+        )
+    )
+
+    log.info(f"leagues: {action} for {caller.user_id} -> {len(leagues)} leagues")
+    return success_response({"season": season, "count": len(leagues), "leagues": leagues})

--- a/lambdas/api_users_me/handler.py
+++ b/lambdas/api_users_me/handler.py
@@ -22,11 +22,11 @@ being stored and failing later during roster matching.
 """
 from typing import Any
 
-from lambdas.common import platform_users
+from lambdas.common import platform_follows, platform_users
 from lambdas.common.caller_identity import get_caller
 from lambdas.common.errors import ValidationError, handle_errors
 from lambdas.common.logger import get_logger
-from lambdas.common.sleeper_helper import get_sleeper_user
+from lambdas.common.sleeper_helper import get_nfl_state, get_sleeper_user, get_user_leagues
 from lambdas.common.utility_helpers import parse_body, success_response
 
 HANDLER = "api_users_me"
@@ -94,12 +94,44 @@ def _link(user_id: str, event: dict[str, Any]) -> dict[str, Any]:
     if not profile or not profile.get("user_id"):
         raise ValidationError(f"No Sleeper account found for '{username}'")
 
-    return platform_users.link_sleeper(
+    sleeper_user_id = str(profile["user_id"])
+    record = platform_users.link_sleeper(
         user_id=user_id,
-        sleeper_user_id=str(profile["user_id"]),
+        sleeper_user_id=sleeper_user_id,
         sleeper_username=str(profile.get("username") or username),
         avatar=profile.get("avatar"),
     )
+
+    _auto_follow_leagues(user_id, sleeper_user_id)
+    return record
+
+
+def _auto_follow_leagues(user_id: str, sleeper_user_id: str) -> None:
+    """Follow everything this Sleeper account is already in.
+
+    Without it a freshly linked user has an empty app and no obvious way to
+    fill it. `follow_many` skips leagues already followed, so re-linking
+    never resurrects one the user deliberately unfollowed.
+
+    Best-effort: a Sleeper outage must not fail the link itself, which is the
+    step the user actually asked for and the one the guard is waiting on.
+    """
+    try:
+        season = str((get_nfl_state() or {}).get("season") or "")
+        if not season:
+            return
+        leagues = [
+            {
+                "leagueId": str(l.get("league_id") or ""),
+                "name": l.get("name") or "",
+                "season": str(l.get("season") or ""),
+            }
+            for l in get_user_leagues(sleeper_user_id, season)
+            if l.get("league_id")
+        ]
+        platform_follows.follow_many(user_id, leagues)
+    except Exception as err:
+        log.warning(f"users/me: auto-follow skipped for {user_id} - {err}")
 
 
 @handle_errors(HANDLER)

--- a/lambdas/common/constants.py
+++ b/lambdas/common/constants.py
@@ -109,3 +109,7 @@ STATS_TABLE_NAME = os.environ.get("STATS_TABLE", "xomper-stats-current")
 # Platform identity (Phase 4.6). Cognito holds credentials; this table holds
 # what Cognito does not — which Sleeper account a user has linked.
 PLATFORM_USERS_TABLE = os.environ.get("PLATFORM_USERS_TABLE", "xomper-users")
+
+# Followed leagues (Phase 4.8). The inversion of whitelisted_leagues, and the
+# cost control: scheduled work iterates followed leagues only.
+PLATFORM_FOLLOWS_TABLE = os.environ.get("PLATFORM_FOLLOWS_TABLE", "xomper-follows")

--- a/lambdas/common/platform_follows.py
+++ b/lambdas/common/platform_follows.py
@@ -1,0 +1,156 @@
+"""
+Followed leagues
+================
+The `xomper-follows` table: which leagues a user cares about.
+
+This is the inversion of CLT's `whitelisted_leagues`. Instead of an admin
+allowing leagues in, users follow the leagues they are already in on Sleeper.
+
+**It is the cost control.** Every scheduled job iterates followed leagues, so
+recurring work scales with what people actually use rather than with every
+league on Sleeper. The `leagueId-index` GSI is what lets a cron go the other
+way — from a league to everyone following it — without scanning.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+
+from lambdas.common.constants import PLATFORM_FOLLOWS_TABLE
+from lambdas.common.errors import DynamoDBError
+from lambdas.common.logger import get_logger
+from lambdas.common.utility_helpers import get_iso_timestamp
+
+log = get_logger(__name__)
+
+
+def _table() -> Any:
+    return boto3.resource("dynamodb").Table(PLATFORM_FOLLOWS_TABLE)
+
+
+def _all_rows(user_id: str) -> list[dict[str, Any]]:
+    """Every row for this user, tombstones included."""
+    try:
+        response = _table().query(
+            KeyConditionExpression=Key("userId").eq(user_id)
+        )
+    except ClientError as err:
+        raise DynamoDBError(f"list_for_user failed: {err}") from err
+    return response.get("Items", [])
+
+
+def list_for_user(user_id: str) -> list[dict[str, Any]]:
+    """Every league this user actively follows."""
+    return [row for row in _all_rows(user_id) if not row.get("unfollowed")]
+
+
+def followed_league_ids(user_id: str) -> set[str]:
+    return {str(item["leagueId"]) for item in list_for_user(user_id) if item.get("leagueId")}
+
+
+def _known_league_ids(user_id: str) -> set[str]:
+    """Leagues this user has ever decided about, unfollows included.
+
+    Auto-follow keys on this rather than on the active set, so a league the
+    user deliberately unfollowed is not re-added the next time they link.
+    """
+    return {str(item["leagueId"]) for item in _all_rows(user_id) if item.get("leagueId")}
+
+
+def follow(user_id: str, league_id: str, name: str = "", season: str = "") -> dict[str, Any]:
+    """Start following a league.
+
+    The name and season are denormalised so a cron can report on a league
+    without a Sleeper round trip. They are a snapshot, not a source of truth —
+    a renamed league keeps the old name here until the next follow.
+    """
+    item = {
+        "userId": user_id,
+        "leagueId": league_id,
+        "name": name,
+        "season": season,
+        "followedAt": get_iso_timestamp(),
+        # Overwrites any tombstone from a previous unfollow.
+        "unfollowed": False,
+    }
+    try:
+        _table().put_item(Item=item)
+    except ClientError as err:
+        raise DynamoDBError(f"follow failed: {err}") from err
+
+    log.info(f"follows: {user_id} -> {league_id}")
+    return item
+
+
+def unfollow(user_id: str, league_id: str) -> None:
+    """Stop following a league.
+
+    Tombstoned rather than deleted. A deleted row is indistinguishable from
+    one that never existed, so auto-follow would re-add the league every time
+    the user re-linked their Sleeper account and they would have no way to
+    keep it out.
+    """
+    try:
+        _table().update_item(
+            Key={"userId": user_id, "leagueId": league_id},
+            UpdateExpression="SET unfollowed = :t, unfollowedAt = :at",
+            ExpressionAttributeValues={":t": True, ":at": get_iso_timestamp()},
+        )
+    except ClientError as err:
+        raise DynamoDBError(f"unfollow failed: {err}") from err
+    log.info(f"follows: {user_id} unfollowed {league_id}")
+
+
+def follow_many(user_id: str, leagues: list[dict[str, Any]]) -> int:
+    """Follow several leagues at once, skipping any already followed.
+
+    Used when a user links their Sleeper account: everything they are already
+    in becomes followed, so the app has something to show without asking them
+    to pick first.
+
+    Skips any league the user has already decided about — including ones they
+    unfollowed, which is why this reads `_known_league_ids` and not the active
+    set. Re-linking must not resurrect a league they deliberately removed.
+    """
+    known = _known_league_ids(user_id)
+    fresh = [l for l in leagues if str(l.get("leagueId")) not in known]
+    if not fresh:
+        return 0
+
+    try:
+        with _table().batch_writer() as batch:
+            for league in fresh:
+                batch.put_item(
+                    Item={
+                        "userId": user_id,
+                        "leagueId": str(league["leagueId"]),
+                        "name": str(league.get("name") or ""),
+                        "season": str(league.get("season") or ""),
+                        "followedAt": get_iso_timestamp(),
+                        "unfollowed": False,
+                    }
+                )
+    except ClientError as err:
+        raise DynamoDBError(f"follow_many failed: {err}") from err
+
+    log.info(f"follows: {user_id} auto-followed {len(fresh)} leagues")
+    return len(fresh)
+
+
+def followers_of(league_id: str) -> list[str]:
+    """Every user following a league. The read path for scheduled jobs."""
+    try:
+        response = _table().query(
+            IndexName="leagueId-index",
+            KeyConditionExpression=Key("leagueId").eq(league_id),
+        )
+    except ClientError as err:
+        raise DynamoDBError(f"followers_of failed: {err}") from err
+    return [
+        str(item["userId"])
+        for item in response.get("Items", [])
+        if item.get("userId") and not item.get("unfollowed")
+    ]

--- a/lambdas/common/sleeper_helper.py
+++ b/lambdas/common/sleeper_helper.py
@@ -61,6 +61,16 @@ def get_sleeper_user(user_id: str) -> dict[str, Any]:
     return _get(url, "Error getting Sleeper user")
 
 
+def get_user_leagues(user_id: str, season: str) -> list[dict[str, Any]]:
+    """Every NFL league a user is in for a season.
+
+    Sleeper scopes this by season and mints new league ids each year, so a
+    dynasty league appears here under a different id every season.
+    """
+    url = f"{SLEEPER_URL_BASE}/user/{user_id}/leagues/nfl/{season}"
+    return _get(url, "Error getting user leagues") or []
+
+
 def get_sleeper_league(league_id: str) -> dict[str, Any]:
     """Get a Sleeper league by ID."""
     url = f"{SLEEPER_URL_BASE}/league/{league_id}"

--- a/tests/test_api_users_leagues.py
+++ b/tests/test_api_users_leagues.py
@@ -1,0 +1,216 @@
+"""
+Tests for `lambdas.api_users_leagues.handler`.
+
+This endpoint is what makes Xomper multi-league. The frontend previously read
+one hardcoded league id from its environment, so every user saw the same
+league regardless of which ones they were actually in.
+
+The league list is fetched from Sleeper live rather than stored: membership
+changes without telling us. The follow set is stored, because Sleeper has no
+concept of it.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from lambdas.common.constants import PLATFORM_FOLLOWS_TABLE, PLATFORM_USERS_TABLE
+
+SLEEPER_LEAGUES = [
+    {
+        "league_id": "1394061072742227968",
+        "name": "Smirnoff League",
+        "season": "2026",
+        "status": "pre_draft",
+        "total_rosters": 14,
+        "settings": {"type": 0},
+    },
+    {
+        "league_id": "1317249551823814656",
+        "name": "Charlotte Dynasty League",
+        "season": "2026",
+        "status": "in_season",
+        "total_rosters": 12,
+        "settings": {"type": 2},
+    },
+]
+
+
+@pytest.fixture
+def tables():
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName=PLATFORM_USERS_TABLE,
+            KeySchema=[{"AttributeName": "userId", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "userId", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        dynamodb.create_table(
+            TableName=PLATFORM_FOLLOWS_TABLE,
+            KeySchema=[
+                {"AttributeName": "userId", "KeyType": "HASH"},
+                {"AttributeName": "leagueId", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "userId", "AttributeType": "S"},
+                {"AttributeName": "leagueId", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "leagueId-index",
+                    "KeySchema": [{"AttributeName": "leagueId", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield dynamodb
+
+
+@pytest.fixture
+def mod(tables, monkeypatch):
+    from lambdas.common import platform_follows, platform_users
+
+    importlib.reload(platform_follows)
+    importlib.reload(platform_users)
+    from lambdas.api_users_leagues import handler as handler_mod
+
+    handler_mod = importlib.reload(handler_mod)
+    monkeypatch.setattr(handler_mod, "get_nfl_state", lambda: {"season": "2026"})
+    monkeypatch.setattr(handler_mod, "get_user_leagues", lambda _uid, _s: SLEEPER_LEAGUES)
+
+    # A linked user; without sleeperUserId there are no leagues to list.
+    platform_users.ensure_user("cog-1", "d@x.com")
+    platform_users.link_sleeper("cog-1", "594625531702460416", "domgiordano")
+    return handler_mod
+
+
+def event(method="GET", path="/me/leagues", body=None, sub="cog-1"):
+    return {
+        "httpMethod": method,
+        "path": path,
+        "body": json.dumps(body) if body is not None else None,
+        "requestContext": {"authorizer": {"sub": sub, "email": "d@x.com", "provider": "cognito"}},
+    }
+
+
+def body_of(response):
+    return json.loads(response["body"])
+
+
+def test_lists_the_callers_leagues(mod):
+    response = mod.handler(event(), None)
+
+    assert response["statusCode"] == 200
+    payload = body_of(response)
+    assert payload["count"] == 2
+    assert {l["leagueId"] for l in payload["leagues"]} == {
+        "1394061072742227968",
+        "1317249551823814656",
+    }
+
+
+def test_derives_dynasty_from_the_settings_type(mod):
+    leagues = {l["leagueId"]: l for l in body_of(mod.handler(event(), None))["leagues"]}
+
+    # The value provider routes on this: dynasty prices off FantasyCalc,
+    # redraft off projections. Getting it wrong silently prices a league with
+    # the wrong source.
+    assert leagues["1317249551823814656"]["isDynasty"] is True
+    assert leagues["1394061072742227968"]["isDynasty"] is False
+
+
+def test_reports_follow_state(mod):
+    mod.platform_follows.follow("cog-1", "1317249551823814656")
+
+    leagues = {l["leagueId"]: l for l in body_of(mod.handler(event(), None))["leagues"]}
+
+    assert leagues["1317249551823814656"]["isFollowed"] is True
+    assert leagues["1394061072742227968"]["isFollowed"] is False
+
+
+def test_sorts_followed_and_in_season_first(mod):
+    mod.platform_follows.follow("cog-1", "1394061072742227968")
+
+    order = [l["leagueId"] for l in body_of(mod.handler(event(), None))["leagues"]]
+
+    # Followed beats in-season: the switcher shows what the user chose first.
+    assert order[0] == "1394061072742227968"
+
+
+def test_follow_then_list_marks_it_followed(mod):
+    response = mod.handler(
+        event(method="PUT", path="/me/follow", body={"leagueId": "1317249551823814656"}),
+        None,
+    )
+
+    leagues = {l["leagueId"]: l for l in body_of(response)["leagues"]}
+    assert leagues["1317249551823814656"]["isFollowed"] is True
+
+
+def test_unfollow_clears_it(mod):
+    mod.platform_follows.follow("cog-1", "1317249551823814656")
+
+    response = mod.handler(
+        event(method="DELETE", path="/me/unfollow", body={"leagueId": "1317249551823814656"}),
+        None,
+    )
+
+    leagues = {l["leagueId"]: l for l in body_of(response)["leagues"]}
+    assert leagues["1317249551823814656"]["isFollowed"] is False
+
+
+def test_follow_requires_a_league_id(mod):
+    response = mod.handler(event(method="PUT", path="/me/follow", body={}), None)
+
+    assert response["statusCode"] == 400
+
+
+def test_an_unlinked_user_gets_an_empty_list_not_an_error(mod):
+    mod.platform_users.unlink_sleeper("cog-1")
+
+    response = mod.handler(event(), None)
+
+    # The frontend guard already routes unlinked users to the link page; this
+    # endpoint should not be a second place that decides what unlinked means.
+    assert response["statusCode"] == 200
+    assert body_of(response)["leagues"] == []
+
+
+def test_missing_authorizer_context_is_rejected(mod):
+    bare = event()
+    bare["requestContext"] = {}
+
+    assert mod.handler(bare, None)["statusCode"] == 401
+
+
+def test_identity_comes_from_the_authorizer_not_the_body(mod):
+    mod.platform_follows.follow("cog-2", "1317249551823814656")
+
+    leagues = {
+        l["leagueId"]: l
+        for l in body_of(mod.handler(event(body={"userId": "cog-2"}), None))["leagues"]
+    }
+
+    # cog-2's follow must not show up for cog-1.
+    assert leagues["1317249551823814656"]["isFollowed"] is False
+
+
+def test_response_does_not_pass_sleeper_fields_through(mod, monkeypatch):
+    monkeypatch.setattr(
+        mod,
+        "get_user_leagues",
+        lambda _uid, _s: [{**SLEEPER_LEAGUES[0], "draft_id": "secret", "scoring_settings": {}}],
+    )
+
+    league = body_of(mod.handler(event(), None))["leagues"][0]
+
+    # Explicit allowlist: Sleeper's league object is large and mostly
+    # irrelevant here, and the frontend re-fetches the full one it opens.
+    assert "draft_id" not in league
+    assert "scoring_settings" not in league

--- a/tests/test_api_users_me.py
+++ b/tests/test_api_users_me.py
@@ -15,7 +15,12 @@ import boto3
 import pytest
 from moto import mock_aws
 
-from lambdas.common.constants import PLATFORM_USERS_TABLE
+from lambdas.common.constants import PLATFORM_FOLLOWS_TABLE, PLATFORM_USERS_TABLE
+
+SLEEPER_LEAGUES = [
+    {"league_id": "1317249551823814656", "name": "Charlotte Dynasty League", "season": "2026"},
+    {"league_id": "1389328793713250304", "name": "CLIT Fantasy Football", "season": "2026"},
+]
 
 SLEEPER_PROFILE = {
     "user_id": "594625531702460416",
@@ -36,17 +41,43 @@ def users_table():
             ],
             BillingMode="PAY_PER_REQUEST",
         )
+        # Linking auto-follows the account's leagues, so this table has to
+        # exist for the link path even though this module does not assert on
+        # it beyond the auto-follow cases below.
+        dynamodb.create_table(
+            TableName=PLATFORM_FOLLOWS_TABLE,
+            KeySchema=[
+                {"AttributeName": "userId", "KeyType": "HASH"},
+                {"AttributeName": "leagueId", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "userId", "AttributeType": "S"},
+                {"AttributeName": "leagueId", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "leagueId-index",
+                    "KeySchema": [{"AttributeName": "leagueId", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
         yield dynamodb.Table(PLATFORM_USERS_TABLE)
 
 
 @pytest.fixture
-def mod(users_table):
-    from lambdas.common import platform_users
+def mod(users_table, monkeypatch):
+    from lambdas.common import platform_follows, platform_users
 
+    importlib.reload(platform_follows)
     importlib.reload(platform_users)
     from lambdas.api_users_me import handler as handler_mod
 
-    return importlib.reload(handler_mod)
+    handler_mod = importlib.reload(handler_mod)
+    monkeypatch.setattr(handler_mod, "get_nfl_state", lambda: {"season": "2026"})
+    monkeypatch.setattr(handler_mod, "get_user_leagues", lambda _uid, _s: SLEEPER_LEAGUES)
+    return handler_mod
 
 
 def event(method="GET", path="/me/profile", body=None, sub="cog-1", email="d@x.com"):
@@ -178,3 +209,38 @@ def test_a_method_mismatch_is_rejected(mod):
     )
 
     assert response["statusCode"] == 400
+
+
+def test_linking_auto_follows_the_accounts_leagues(mod, monkeypatch):
+    monkeypatch.setattr(mod, "get_sleeper_user", lambda _: SLEEPER_PROFILE)
+
+    mod.handler(
+        event(method="PUT", path="/me/sleeper-link", body={"sleeperUsername": "dgiordano"}),
+        None,
+    )
+
+    # Without this a freshly linked user lands on an app with no leagues and
+    # no obvious way to add one.
+    assert mod.platform_follows.followed_league_ids("cog-1") == {
+        "1317249551823814656",
+        "1389328793713250304",
+    }
+
+
+def test_a_sleeper_outage_does_not_fail_the_link(mod, monkeypatch):
+    monkeypatch.setattr(mod, "get_sleeper_user", lambda _: SLEEPER_PROFILE)
+
+    def boom(*_args):
+        raise RuntimeError("sleeper down")
+
+    monkeypatch.setattr(mod, "get_user_leagues", boom)
+
+    response = mod.handler(
+        event(method="PUT", path="/me/sleeper-link", body={"sleeperUsername": "dgiordano"}),
+        None,
+    )
+
+    # Linking is the step the user asked for and the one the guard waits on.
+    # Auto-follow is a convenience on top and must not take it down.
+    assert response["statusCode"] == 200
+    assert body_of(response)["user"]["hasLinkedSleeper"] is True

--- a/tests/test_platform_follows.py
+++ b/tests/test_platform_follows.py
@@ -1,0 +1,157 @@
+"""
+Tests for `lambdas.common.platform_follows`.
+
+The follow set is the cost control: scheduled work iterates followed leagues,
+so what is in this table bounds recurring spend. The two behaviours worth
+pinning are that auto-follow does not resurrect a deliberate unfollow, and
+that the GSI answers the cron's question (who follows this league) without a
+scan.
+"""
+from __future__ import annotations
+
+import importlib
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from lambdas.common.constants import PLATFORM_FOLLOWS_TABLE
+
+
+@pytest.fixture
+def follows_table():
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        dynamodb.create_table(
+            TableName=PLATFORM_FOLLOWS_TABLE,
+            KeySchema=[
+                {"AttributeName": "userId", "KeyType": "HASH"},
+                {"AttributeName": "leagueId", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "userId", "AttributeType": "S"},
+                {"AttributeName": "leagueId", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "leagueId-index",
+                    "KeySchema": [{"AttributeName": "leagueId", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield dynamodb.Table(PLATFORM_FOLLOWS_TABLE)
+
+
+@pytest.fixture
+def store(follows_table):
+    from lambdas.common import platform_follows
+
+    return importlib.reload(platform_follows)
+
+
+LEAGUES = [
+    {"leagueId": "1317249551823814656", "name": "Charlotte Dynasty League", "season": "2026"},
+    {"leagueId": "1389328793713250304", "name": "CLIT Fantasy Football", "season": "2026"},
+]
+
+
+def test_no_follows_for_a_new_user(store):
+    assert store.list_for_user("cog-1") == []
+    assert store.followed_league_ids("cog-1") == set()
+
+
+def test_follow_then_list(store):
+    store.follow("cog-1", "1317249551823814656", name="CLT", season="2026")
+
+    items = store.list_for_user("cog-1")
+    assert len(items) == 1
+    assert items[0]["name"] == "CLT"
+    assert items[0]["followedAt"]
+
+
+def test_follow_is_idempotent(store):
+    store.follow("cog-1", "abc")
+    store.follow("cog-1", "abc")
+
+    assert len(store.list_for_user("cog-1")) == 1
+
+
+def test_unfollow_removes_only_that_league(store):
+    store.follow_many("cog-1", LEAGUES)
+
+    store.unfollow("cog-1", "1317249551823814656")
+
+    assert store.followed_league_ids("cog-1") == {"1389328793713250304"}
+
+
+def test_follow_many_adds_all_for_a_new_user(store):
+    added = store.follow_many("cog-1", LEAGUES)
+
+    assert added == 2
+    assert len(store.followed_league_ids("cog-1")) == 2
+
+
+def test_follow_many_skips_ones_already_followed(store):
+    store.follow_many("cog-1", LEAGUES)
+
+    added = store.follow_many("cog-1", LEAGUES)
+
+    assert added == 0
+
+
+def test_follow_many_does_not_resurrect_an_unfollow(store):
+    store.follow_many("cog-1", LEAGUES)
+    store.unfollow("cog-1", "1389328793713250304")
+
+    # Re-linking a Sleeper account runs auto-follow again. It must not undo a
+    # deliberate unfollow, or the league reappears every time and the user
+    # has no way to keep it out.
+    store.follow_many("cog-1", LEAGUES)
+
+    assert store.followed_league_ids("cog-1") == {"1317249551823814656"}
+
+
+def test_follows_are_per_user(store):
+    store.follow("cog-1", "abc")
+    store.follow("cog-2", "xyz")
+
+    assert store.followed_league_ids("cog-1") == {"abc"}
+    assert store.followed_league_ids("cog-2") == {"xyz"}
+
+
+def test_followers_of_answers_the_cron_question(store):
+    store.follow("cog-1", "shared-league")
+    store.follow("cog-2", "shared-league")
+    store.follow("cog-3", "other-league")
+
+    followers = store.followers_of("shared-league")
+
+    # This is the read path for every scheduled job: league -> who cares.
+    assert sorted(followers) == ["cog-1", "cog-2"]
+
+
+def test_followers_of_is_empty_for_an_unfollowed_league(store):
+    assert store.followers_of("nobody-follows-this") == []
+
+
+def test_refollowing_clears_the_tombstone(store):
+    store.follow("cog-1", "abc")
+    store.unfollow("cog-1", "abc")
+
+    store.follow("cog-1", "abc")
+
+    assert store.followed_league_ids("cog-1") == {"abc"}
+    assert store.followers_of("abc") == ["cog-1"]
+
+
+def test_an_unfollowed_league_drops_out_of_the_cron_read(store):
+    store.follow("cog-1", "abc")
+    store.follow("cog-2", "abc")
+
+    store.unfollow("cog-1", "abc")
+
+    # A tombstone must not keep a user on the cron's list, or unfollowing
+    # stops meaning anything for cost.
+    assert store.followers_of("abc") == ["cog-2"]


### PR DESCRIPTION
Backend for multi-league. Infra merged and applied in Xomware/xomper-infrastructure#136.

## The gap this closes

The frontend reads **one hardcoded league id** from `environment.myLeagueId`. Every user sees Charlotte Dynasty League regardless of which leagues they're actually in. A real account:

```
4 leagues for 2026:
  Smirnoff League '26-'27                     14tm  pre_draft   redraft
  CLIT Fantasy Football                       12tm  pre_draft   redraft
  Charlotte Dynasty League                    12tm  in_season   dynasty
  Chris Berman Memorial Fantasy Football      12tm  drafting    dynasty
```

## Endpoints

| Route | Does |
|---|---|
| `GET /me/leagues` | the caller's leagues from Sleeper, merged with follow state |
| `PUT /me/follow` | follow one |
| `DELETE /me/unfollow` | unfollow one |

The league list is **fetched live, not stored** — membership changes without telling us, and a stale list is worse than a slow one. Only the follow set is persisted, because Sleeper has no concept of it.

`isDynasty` is derived from `settings.type == 2` and returned, because the value provider routes on it: dynasty prices off FantasyCalc, redraft off projections. Getting it wrong silently prices a league from the wrong source, so it's pinned by a test.

Response is an explicit allowlist, not a passthrough — Sleeper's league object is large and mostly irrelevant here, and the frontend re-fetches the full one it actually opens.

## Auto-follow on link

Linking a Sleeper account follows everything that account is in, so a new user doesn't land on an empty app with no obvious way to fill it.

**Best-effort by design:** a Sleeper outage must not fail the link, which is the step the user asked for and the one the auth guard is waiting on. Covered by a test.

## The bug a test caught

`unfollow` originally deleted the row. `follow_many` skipped leagues *currently followed* — but an unfollowed league isn't in that set, so **re-linking resurrected it**, exactly the behaviour my own docstring claimed it avoided.

Unfollow now **tombstones** (`unfollowed: true`) and auto-follow keys on "leagues the user has ever decided about" rather than the active set. `followers_of` — the read path every cron will use — filters tombstones out, so unfollowing still means something for cost.

## Cost control

This is the inversion of CLT's `whitelisted_leagues`: instead of an admin allowing leagues in, users follow leagues they're already in. Scheduled work iterates followed leagues, so recurring spend scales with real usage. The `leagueId-index` GSI is what lets a cron go league → followers without a scan.

Nothing reads it on that path yet — wiring the crons is separate.

## Verification

`676 tests pass` on 3.13 (up from 651). 23 new specs across the store and both handlers. `test_platform_follows.py` added to the common-module list in the deploy workflow.

I'll exercise all three routes against production with a real Cognito token after deploy.